### PR TITLE
Implement FJS formatting

### DIFF
--- a/src/__tests__/interval.spec.ts
+++ b/src/__tests__/interval.spec.ts
@@ -1,0 +1,42 @@
+import {describe, it, expect} from 'vitest';
+import {TimeMonzo} from '../monzo';
+import {timeMonzoAs} from '../interval';
+import {FractionLiteral, NedjiLiteral} from '../expression';
+
+describe('Idempontent formatting', () => {
+  it('has stable ratios (common factor)', () => {
+    const sixOverFour = TimeMonzo.fromFraction('6/4', 2);
+    const node = timeMonzoAs(sixOverFour, {
+      type: 'FractionLiteral',
+      numerator: 6n,
+      denominator: 4n,
+    }) as FractionLiteral;
+    expect(node.numerator).toBe(6n);
+    expect(node.denominator).toBe(4n);
+  });
+
+  it('has stable ratios (denominator)', () => {
+    const fourOverThree = TimeMonzo.fromFraction('4/3', 2);
+    const node = timeMonzoAs(fourOverThree, {
+      type: 'FractionLiteral',
+      numerator: 1n,
+      denominator: 6n,
+    }) as FractionLiteral;
+    expect(node.numerator).toBe(8n);
+    expect(node.denominator).toBe(6n);
+    const iterated = timeMonzoAs(fourOverThree, node) as FractionLiteral;
+    expect(iterated.numerator).toBe(8n);
+    expect(iterated.denominator).toBe(6n);
+  });
+
+  it('has stable equal temperament', () => {
+    const majorThird = TimeMonzo.fromEqualTemperament('4/12');
+    const node = timeMonzoAs(majorThird, {
+      type: 'NedoLiteral',
+      numerator: 4n,
+      denominator: 12n,
+    }) as NedjiLiteral;
+    expect(node.numerator).toBe(4n);
+    expect(node.denominator).toBe(12n);
+  });
+});

--- a/src/__tests__/monzo.spec.ts
+++ b/src/__tests__/monzo.spec.ts
@@ -2,7 +2,6 @@ import {describe, it, expect} from 'vitest';
 import {Fraction, valueToCents} from 'xen-dev-utils';
 
 import {TimeMonzo} from '../monzo';
-import {FractionLiteral, NedjiLiteral} from '../expression';
 
 describe('Extended Monzo', () => {
   it('can be constructed from an integer', () => {
@@ -323,43 +322,5 @@ describe('Extended Monzo', () => {
     expect(eight.isPowerOfTwo()).toBeTruthy();
     const six = TimeMonzo.fromFraction(6, 2);
     expect(six.isPowerOfTwo()).toBeFalsy();
-  });
-});
-
-describe('Idempontent formatting', () => {
-  it('has stable ratios (common factor)', () => {
-    const sixOverFour = TimeMonzo.fromFraction('6/4', 2);
-    const node = sixOverFour.as({
-      type: 'FractionLiteral',
-      numerator: 6n,
-      denominator: 4n,
-    }) as FractionLiteral;
-    expect(node.numerator).toBe(6n);
-    expect(node.denominator).toBe(4n);
-  });
-
-  it('has stable ratios (denominator)', () => {
-    const fourOverThree = TimeMonzo.fromFraction('4/3', 2);
-    const node = fourOverThree.as({
-      type: 'FractionLiteral',
-      numerator: 1n,
-      denominator: 6n,
-    }) as FractionLiteral;
-    expect(node.numerator).toBe(8n);
-    expect(node.denominator).toBe(6n);
-    const iterated = fourOverThree.as(node) as FractionLiteral;
-    expect(iterated.numerator).toBe(8n);
-    expect(iterated.denominator).toBe(6n);
-  });
-
-  it('has stable equal temperament', () => {
-    const majorThird = TimeMonzo.fromEqualTemperament('4/12');
-    const node = majorThird.as({
-      type: 'NedoLiteral',
-      numerator: 4n,
-      denominator: 12n,
-    }) as NedjiLiteral;
-    expect(node.numerator).toBe(4n);
-    expect(node.denominator).toBe(12n);
   });
 });

--- a/src/__tests__/parser.spec.ts
+++ b/src/__tests__/parser.spec.ts
@@ -178,6 +178,26 @@ describe('SonicWeave expression evaluator', () => {
     expect(greenFifth.color?.value).toBe('#008000');
     expect(greenFifth.label).toBe('fifth');
   });
+
+  it('can format the half eleventh', () => {
+    const neutralSixth = parseSingle('P11 % 2');
+    expect(neutralSixth.toString()).toBe('n6');
+  });
+
+  it('can format the double tone', () => {
+    const majorThird = parseSingle('M2 * 2');
+    expect(majorThird.toString()).toBe('M3');
+  });
+
+  it('can format the half twelfth', () => {
+    const majorSixAndAHalfth = parseSingle('P12 % 2');
+    expect(majorSixAndAHalfth.toString()).toBe('M6.5');
+  });
+
+  it("bails out when there's no Pythagorean to match", () => {
+    const thirdFifth = parseSingle('P5 % 3');
+    expect(thirdFifth.toString()).toBe('1\\3<3/2>');
+  });
 });
 
 describe('SonicWeave parser', () => {
@@ -461,7 +481,19 @@ describe('SonicWeave parser', () => {
     );
   });
 
-  it('can rig ups-and-downs', () => {
+  it('can rig ups-and-downs (builtin)', () => {
+    const scale = parseSource(`
+      vM3
+      P5
+      ^m6
+      P8
+      upsAs(81/80)
+    `);
+    expect(scale).toHaveLength(4);
+    expect(scale.map(i => i.toString()).join(';')).toBe('M3^5;P5;m6_5;P8');
+  });
+
+  it('can rig ups-and-downs (manual)', () => {
     const scale = parseSource(`
       riff rig i {
         ups = round(1!€ dot i);

--- a/src/__tests__/pythagorean.spec.ts
+++ b/src/__tests__/pythagorean.spec.ts
@@ -4,7 +4,9 @@ import {
   absoluteMonzo,
   Pythagorean,
   AbsolutePitch,
+  monzoToNode,
 } from '../pythagorean';
+import {TimeMonzo} from '../monzo';
 
 describe('Pythagorean interval construction from parts', () => {
   it.each([
@@ -143,5 +145,67 @@ describe('Absolute Pythagorean interval construction from parts', () => {
     ).toBe(true);
     expect(monzo.residual.equals(1)).toBe(true);
     expect(monzo.cents).toBeCloseTo(0);
+  });
+});
+
+describe('Monzo -> node converter', () => {
+  it('converts a perfect fifth', () => {
+    const node = monzoToNode(TimeMonzo.fromFraction('3/2'));
+    expect(node).toEqual({
+      type: 'Pythagorean',
+      quality: 'P',
+      imperfect: false,
+      degree: {base: 5, negative: false, octaves: 0},
+    });
+  });
+
+  it('converts a major third', () => {
+    const node = monzoToNode(TimeMonzo.fromFraction('81/64'));
+    expect(node).toEqual({
+      type: 'Pythagorean',
+      quality: 'M',
+      imperfect: true,
+      degree: {base: 3, negative: false, octaves: 0},
+    });
+  });
+
+  it('converts a doubly augmented octave', () => {
+    const node = monzoToNode(TimeMonzo.fromFraction('4782969/2097152'));
+    expect(node).toEqual({
+      type: 'Pythagorean',
+      quality: 'AA',
+      imperfect: false,
+      degree: {base: 1, negative: false, octaves: 1},
+    });
+  });
+
+  it('converts a doubly diminished seventh', () => {
+    const node = monzoToNode(TimeMonzo.fromFraction('67108864/43046721'));
+    expect(node).toEqual({
+      type: 'Pythagorean',
+      quality: 'dd',
+      imperfect: true,
+      degree: {base: 7, negative: false, octaves: 0},
+    });
+  });
+
+  it('converts a neutral third', () => {
+    const node = monzoToNode(TimeMonzo.fromEqualTemperament('1/2', '3/2'));
+    expect(node).toEqual({
+      type: 'Pythagorean',
+      quality: 'n',
+      imperfect: true,
+      degree: {base: 3, negative: false, octaves: 0},
+    });
+  });
+
+  it('converts a half-octave', () => {
+    const node = monzoToNode(TimeMonzo.fromEqualTemperament('1/2'));
+    expect(node).toEqual({
+      type: 'Pythagorean',
+      quality: 'n',
+      imperfect: true,
+      degree: {base: 4.5, negative: false, octaves: 0},
+    });
   });
 });

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -1,5 +1,5 @@
 import {Fraction, kCombinations, mmod, isPrime, primes} from 'xen-dev-utils';
-import {Color, Interval} from './interval';
+import {Color, Interval, timeMonzoAs} from './interval';
 import {TimeMonzo} from './monzo';
 import {ExpressionVisitor} from './parser';
 
@@ -85,6 +85,21 @@ function mosSubset(...args: (Interval | undefined)[]) {
   );
   const result = mos(...(iargs as [number, number]));
   return result.map(Interval.fromInteger);
+}
+
+function upsAs(comma: Interval) {
+  const inflection = comma.value;
+  function upRigger(interval: Interval) {
+    const ups = Math.round(interval.value.cents);
+    const value = interval.value.mul(inflection.pow(ups));
+    value.cents = 0;
+    return new Interval(
+      value,
+      interval.domain,
+      timeMonzoAs(value, interval.node)
+    );
+  }
+  return upRigger;
 }
 
 function zip(...args: any[][]) {
@@ -236,7 +251,7 @@ export function relog(this: ExpressionVisitor, interval: Interval) {
 
 export function cents(this: ExpressionVisitor, interval: Interval) {
   const converted = relog.bind(this)(interval);
-  converted.node = converted.value.as({
+  converted.node = timeMonzoAs(converted.value, {
     type: 'CentsLiteral',
     whole: 0n,
     fractional: '',
@@ -330,6 +345,7 @@ export const BUILTIN_CONTEXT: Record<string, Interval | Function> = {
   mosSubset,
   isPrime: isPrime_,
   primes: primes_,
+  upsAs,
   zip,
   zipLongest,
   abs,

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -144,6 +144,20 @@ export function uniformInvertNode(
   return undefined;
 }
 
+export function upNode(node?: IntervalLiteral): IntervalLiteral | undefined {
+  if (!node) {
+    return undefined;
+  }
+  switch (node.type) {
+    case 'FJS':
+      return {
+        ...node,
+        downs: node.downs - 1,
+      };
+  }
+  return undefined;
+}
+
 export function addNodes(
   a?: IntervalLiteral,
   b?: IntervalLiteral
@@ -272,6 +286,19 @@ function tailFJS(literal: FJS | AbsoluteFJS) {
   return result;
 }
 
+function formatFJS(literal: FJS) {
+  let ups: string;
+  if (literal.downs > 0) {
+    ups = 'v'.repeat(literal.downs);
+  } else {
+    ups = '^'.repeat(-literal.downs);
+  }
+  const d = literal.pythagorean.degree;
+  return `${ups}${literal.pythagorean.quality}${d.negative ? '-' : ''}${
+    d.base + 7 * d.octaves
+  }${tailFJS(literal)}`;
+}
+
 function formatDecimal(literal: DecimalLiteral) {
   let result = literal.whole.toString();
   if (literal.fractional) {
@@ -326,11 +353,7 @@ export function toString(literal: IntervalLiteral) {
     case 'FalseLiteral':
       return 'false';
     case 'FJS':
-      // eslint-disable-next-line no-case-declarations
-      const d = literal.pythagorean.degree;
-      return `${literal.pythagorean.quality}${d.negative ? '-' : ''}${
-        d.base + 7 * d.octaves
-      }${tailFJS(literal)}`;
+      return formatFJS(literal);
     case 'AbsoluteFJS':
       // eslint-disable-next-line no-case-declarations
       const p = literal.pitch;

--- a/src/monzo.ts
+++ b/src/monzo.ts
@@ -16,7 +16,6 @@ import {
 import {NEGATIVE_ONE, ONE, TWO, ZERO, bigGcd} from './utils';
 import {
   NedjiLiteral,
-  IntervalLiteral,
   FractionLiteral,
   CentsLiteral,
   IntegerLiteral,
@@ -1126,25 +1125,6 @@ export class TimeMonzo {
       result = result.inverse().add(continuedFraction[i]);
     }
     return TimeMonzo.fromFraction(result, this.numberOfComponents);
-  }
-
-  // TODO: Make sure that this is idempotent.
-  as(node: IntervalLiteral | undefined): IntervalLiteral | undefined {
-    if (!node) {
-      return undefined;
-    }
-    switch (node.type) {
-      case 'IntegerLiteral':
-        return this.asIntegerLiteral(node);
-      case 'FractionLiteral':
-        return this.asFractionLiteral(node);
-      case 'NedoLiteral':
-        return this.asNedjiLiteral(node);
-      case 'CentsLiteral':
-        return this.asCentsLiteral(node);
-      default:
-        return undefined;
-    }
   }
 
   asCentsLiteral(node: CentsLiteral): CentsLiteral {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -17,7 +17,7 @@ import {
   formatComponent,
   ValLiteral,
 } from './expression';
-import {Interval, Color, Domain} from './interval';
+import {Interval, Color, Domain, timeMonzoAs} from './interval';
 import {TimeMonzo} from './monzo';
 import {parse} from './sonic-weave-ast';
 import {CSS_COLOR_CONTEXT} from './css-colors';
@@ -644,9 +644,9 @@ function resolvePreference(
     return new Interval(value, domain);
   }
   if (node.preferLeft) {
-    return new Interval(value, left.domain, value.as(left.node));
+    return new Interval(value, left.domain, timeMonzoAs(value, left.node));
   }
-  return new Interval(value, right.domain, value.as(right.node));
+  return new Interval(value, right.domain, timeMonzoAs(value, right.node));
 }
 
 export class ExpressionVisitor {

--- a/src/sonic-weave.pegjs
+++ b/src/sonic-weave.pegjs
@@ -311,7 +311,7 @@ ExponentiationOperator
   = '^'
 
 ExponentiationExpression
-  = head: LabeledExpression tail: (_ @'~'? @ExponentiationOperator @'~'? _ @ExponentiationExpression)* {
+  = head: LabeledExpression tail: (_ @'~'? @ExponentiationOperator !(FJS / AbsoluteFJS) @'~'? _ @ExponentiationExpression)* {
       return tail.reduce(operatorReducer, head);
     }
 


### PR DESCRIPTION
Move node formatting out of TimeMonzo to avoid circular imports.

Prefer unary ^ over exponentiation with FJS