### PR TITLE
Convert NEDJI projection to a binary operation with 'ed'

### DIFF
--- a/BUILTIN.md
+++ b/BUILTIN.md
@@ -422,9 +422,6 @@ Calculate the denominator of x in reduced form.
 ### diff(*array*)
 Calculate the (linear) differences between the terms.
 
-### ed(*divisions*, *equave = 2*)
-Generate an equal temperament with the given number of divisions of the given equave/octave.
-
 ### edColors(*divisions = 12*, *offset = 0*, *equave = 2*)
 Color every interval in the scale with hue repeating every step of an equal division of `equave`. `offset` rotates the hue wheel.
 
@@ -658,6 +655,9 @@ Calculate the (linear) sum of the terms or the current scale.
 
 ### tanh(*x*)
 Calculate the hyperbolic tangent of x.
+
+### tet(*divisions*, *equave = 2*)
+Generate an equal temperament with the given number of divisions of the given equave/octave.
 
 ### toHarmonics(*fundamental*, *scale = $$*)
 Quantize the current/given scale to harmonics of the given fundamental.

--- a/README.md
+++ b/README.md
@@ -155,29 +155,31 @@ Outer product a.k.a. tensoring expands all possible products in two arrays into 
 ]
 ```
 ### Interval
-| Name                   | Linear       | Result   | Logarithmic      | Result  |
-| ---------------------- | ------------ | -------- | ---------------- | ------- |
-| Addition               | `3 + 5`      | `8`      | _N/A_            |         |
-| Subtraction            | `5 - 3`      | `2`      | _N/A_            |         |
-| Modulo                 | `5 mod 3`    | `2`      | _N/A_            |         |
-| Ceiling modulo         | `0 modc 3`   | `3`      | _N/A_            |         |
-| Round (to multiple of) | `5 to 3`     | `6`      | _N/A_            |         |
-| Minimum                | `2 min 1`    | `1`      | `P8 min P1`      | `P1`    |
-| Maximum                | `2 max 1`    | `2`      | `P8 max P1`      | `P8`    |
-| Multiplication         | `2 * 3`      | `6`      | `P8 + P12`       | `P19`   |
-| Multiplication         | `110 Hz × 5` | `550 Hz` | `A♮2 + M17^5`    | `C♯5^5` |
-| Division               | `6 % 2`      | `3`      | `P19 - P8`       | `P12`   |
-| Division               | `220 hz ÷ 2` | `110 Hz` | `A=3 - P8`       | `A=2`   |
-| Reduction              | `5 rd 2`     | `5/4`    | `M17^5 mod P8`   | `M3^5`  |
-| Ceiling reduction      | `2 rdc 2`    | `2`      | `P8 modc P8`     | `P8`    |
-| Exponentiation         | `3 ^ 2`      | `9`      | `P12 * 2`        | `M23`   |
-| Recipropower           | `9 /^ 2`     | `3`      | `M23 % 2`        | `P12`   |
-| Root taking            | `9 ^/ 2`     | `3`      | `M23 % 2`        | `P12`   |
-| Logarithm (in base of) | `9 /_ 3`     | `2`      | `M23 % P12`      | `2`     |
-| Round (to power of)    | `5 by 2`     | `4`      | `M17^5 to P8`    | `P15`   |
-| N of EDO               | `(5+2)\12`   | `7\12`   | _N/A_            |         |
-| NEDJI Projection       | `sqrt(2)<3>` | `1\2<3>` | _N/A_            |         |
-| Val product            | `12@ · 3/2`  | `7`      | `<12 19] dot P5` | `7`     |
+| Name                   | Linear         | Result   | Logarithmic      | Result     |
+| ---------------------- | -------------- | -------- | ---------------- | ---------- |
+| Addition               | `3 + 5`        | `8`      | _N/A_            |            |
+| Subtraction            | `5 - 3`        | `2`      | _N/A_            |            |
+| Modulo                 | `5 mod 3`      | `2`      | _N/A_            |            |
+| Ceiling modulo         | `0 modc 3`     | `3`      | _N/A_            |            |
+| Round (to multiple of) | `5 to 3`       | `6`      | _N/A_            |            |
+| Minimum                | `2 min 1`      | `1`      | `P8 min P1`      | `P1`       |
+| Maximum                | `2 max 1`      | `2`      | `P8 max P1`      | `P8`       |
+| Multiplication         | `2 * 3`        | `6`      | `P8 + P12`       | `P19`      |
+| Multiplication         | `110 Hz × 5`   | `550 Hz` | `A♮2 + M17^5`    | `C♯5^5`    |
+| Division               | `6 % 2`        | `3`      | `P19 - P8`       | `P12`      |
+| Division               | `220 hz ÷ 2`   | `110 Hz` | `A=3 - P8`       | `A=2`      |
+| Reduction              | `5 rd 2`       | `5/4`    | `M17^5 mod P8`   | `M3^5`     |
+| Ceiling reduction      | `2 rdc 2`      | `2`      | `P8 modc P8`     | `P8`       |
+| Exponentiation         | `3 ^ 2`        | `9`      | `P12 * 2`        | `M23`      |
+| Recipropower           | `9 /^ 2`       | `3`      | `M23 % 2`        | `P12`      |
+| Root taking            | `9 ^/ 2`       | `3`      | `M23 % 2`        | `P12`      |
+| Logarithm (in base of) | `9 /_ 3`       | `2`      | `M23 % P12`      | `2`        |
+| Round (to power of)    | `5 by 2`       | `4`      | `M17^5 to P8`    | `P15`      |
+| N of EDO               | `(5+2)\12`     | `7\12`   | _N/A_            |            |
+| NEDJI Projection       | `sqrt(2) ed 3` | `1\2<3>` | `2\3 ed S3`      | `2\3<9/8>` |
+| Val product            | `12@ · 3/2`    | `7`      | `<12 19] dot P5` | `7`        |
+
+Of these NEDJI Projection is probably the most obtuse, so a few words are in order. In `octaves ed base` the `base` operand is raised to the two's exponent of `octaves`. Exponents of all other primes are discarded. The result is alway is in the logarithmic domain. e.g. `[7/13 1 1> ed 5` discards the `1` components and moves/projects the first component to the third slot (corresponding to prime five) resulting in `[0 0 7\13>`.
 
 #### Universal operators and preference
 

--- a/src/__tests__/parser/expression.spec.ts
+++ b/src/__tests__/parser/expression.spec.ts
@@ -944,7 +944,10 @@ describe('SonicWeave expression evaluator', () => {
   });
 
   it('has quick nedji subset', () => {
-    const scale = evaluateExpression('[1, 2, 5] \\ 13<3>', false) as Interval[];
+    const scale = evaluateExpression(
+      '[1, 2, 5] \\ 13 ed 3',
+      false
+    ) as Interval[];
     expect(scale.map(i => i.toString())).toEqual([
       '1\\13<3>',
       '2\\13<3>',
@@ -1524,5 +1527,10 @@ describe('SonicWeave expression evaluator', () => {
   it('uses w before u in step strings', () => {
     const pattern = evaluateExpression('8::16;stepString()', false);
     expect(pattern).toBe('BHLMnstw');
+  });
+
+  it('has a comfortable precedence between addition, min and max', () => {
+    const five = parseSingle('2 + 1 min 3 - 4 max 5');
+    expect(five.toString()).toBe('5');
   });
 });

--- a/src/__tests__/parser/source.spec.ts
+++ b/src/__tests__/parser/source.spec.ts
@@ -1192,4 +1192,18 @@ describe('SonicWeave parser', () => {
     `);
     expect(scale).toEqual(['6/5', '4/3', '7/4', '2/1']);
   });
+
+  it('can approximate an entire harmonic segment', () => {
+    const scale = parseSource('8::16 by~ 1\\12;str');
+    expect(scale).toEqual([
+      '2\\12',
+      '4\\12',
+      '6\\12',
+      '7\\12',
+      '8\\12',
+      '10\\12',
+      '11\\12',
+      '12\\12',
+    ]);
+  });
 });

--- a/src/__tests__/parser/stdlib.spec.ts
+++ b/src/__tests__/parser/stdlib.spec.ts
@@ -36,7 +36,7 @@ describe('SonicWeave standard library', () => {
   });
 
   it('generates equal temperaments', () => {
-    const scale = parseSource('ed(6);');
+    const scale = parseSource('tet(6);');
     expect(scale).toHaveLength(6);
     expect(scale.map(i => i.toString()).join(';')).toBe(
       '1\\6;2\\6;3\\6;4\\6;5\\6;6\\6'
@@ -44,7 +44,7 @@ describe('SonicWeave standard library', () => {
   });
 
   it('generates tritave equivalent equal temperaments', () => {
-    const scale = parseSource('ed(3,3);');
+    const scale = parseSource('tet(3,3);');
     expect(scale).toHaveLength(3);
     expect(scale.map(i => i.toString()).join(';')).toBe(
       '1\\3<3>;2\\3<3>;3\\3<3>'
@@ -127,13 +127,13 @@ describe('SonicWeave standard library', () => {
   });
 
   it('can take edo subsets', () => {
-    const scale = parseSource('ed(7);subset([0, 1, 2]);');
+    const scale = parseSource('tet(7);subset([0, 1, 2]);');
     expect(scale).toHaveLength(3);
     expect(scale.map(i => i.toString()).join(';')).toBe('1\\7;2\\7;7\\7');
   });
 
   it('can take relative edo subsets', () => {
-    const scale = parseSource('ed(12);subset(cumsum([0, 2, 2, 1, 2, 2, 2]));');
+    const scale = parseSource('tet(12);subset(cumsum([0, 2, 2, 1, 2, 2, 2]));');
     expect(scale).toHaveLength(7);
     expect(scale.map(i => i.toString()).join(';')).toBe(
       '2\\12;4\\12;5\\12;7\\12;9\\12;11\\12;12\\12'

--- a/src/__tests__/sonic-weave-ast.spec.ts
+++ b/src/__tests__/sonic-weave-ast.spec.ts
@@ -472,30 +472,34 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
   });
 
   it('parses N-steps-of-M-equal-divisions-of-just-intonation (literal)', () => {
-    const ast = parseSingle('(7\\13)<3>');
+    const ast = parseSingle('7\\13 ed 3');
     expect(ast).toEqual({
       type: 'ExpressionStatement',
       expression: {
-        type: 'NedjiProjection',
-        octaves: {
+        type: 'BinaryExpression',
+        operator: 'ed',
+        left: {
           type: 'NedjiLiteral',
           numerator: 7,
           denominator: 13,
           equaveNumerator: null,
           equaveDenominator: null,
         },
-        base: {type: 'IntegerLiteral', value: 3n},
+        right: {type: 'IntegerLiteral', value: 3n},
+        preferLeft: false,
+        preferRight: false,
       },
     });
   });
 
   it('parses N-steps-of-equal-divisions-of-just-intonation (binary expression)', () => {
-    const ast = parseSingle('n\\m<ji>');
+    const ast = parseSingle('n\\m ed ji');
     expect(ast).toEqual({
       type: 'ExpressionStatement',
       expression: {
-        type: 'NedjiProjection',
-        octaves: {
+        type: 'BinaryExpression',
+        operator: 'ed',
+        left: {
           type: 'BinaryExpression',
           operator: '\\',
           left: {type: 'Identifier', id: 'n'},
@@ -503,7 +507,9 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
           preferLeft: false,
           preferRight: false,
         },
-        base: {type: 'Identifier', id: 'ji'},
+        right: {type: 'Identifier', id: 'ji'},
+        preferLeft: false,
+        preferRight: false,
       },
     });
   });
@@ -909,7 +915,7 @@ describe('Automatic semicolon insertion', () => {
   });
 
   it('works with nedji projection', () => {
-    const ast = parse('(1\\2)<3>\n2\\2<(3)>');
+    const ast = parse('(1\\2) ed 3\n2\\2 ed (3)');
     expect(ast.body).toHaveLength(2);
   });
 });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -36,6 +36,7 @@ export type BinaryOperator =
   | 'modc'
   | 'rd'
   | 'rdc'
+  | 'ed'
   | '/_'
   | '·'
   | 'dot'
@@ -250,12 +251,6 @@ export type LabeledExpression = {
   labels: (Identifier | ColorLiteral | StringLiteral | NoneLiteral)[];
 };
 
-export type NedjiProjection = {
-  type: 'NedjiProjection';
-  octaves: Expression;
-  base: Expression;
-};
-
 export type NoneLiteral = {
   type: 'NoneLiteral';
 };
@@ -348,7 +343,6 @@ export type Expression =
   | DownExpression
   | BinaryExpression
   | LabeledExpression
-  | NedjiProjection
   | CallExpression
   | ArrowFunction
   | IntervalLiteral

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -2408,11 +2408,11 @@ riff edColors(divisions = 12, offset = 0, equave = 2) {
 }
 
 // == Scale generation ==
-riff ed(divisions, equave = 2) {
+riff tet(divisions, equave = 2) {
   "Generate an equal temperament with the given number of divisions of the given equave/octave.";
   [1..divisions];
   if (equave === 2) step => step \\ divisions;
-  else step => step \\ divisions < equave >;
+  else step => step \\ divisions ed equave;
 }
 
 riff subharmonics(start, end) {
@@ -2428,7 +2428,7 @@ riff mos(numberOfLargeSteps, numberOfSmallSteps, sizeOfLargeStep = 2, sizeOfSmal
   mosSubset(numberOfLargeSteps, numberOfSmallSteps, sizeOfLargeStep, sizeOfSmallStep, up, down);
   const divisions = $[-1];
   if (equave === 2) step => step \\ divisions;
-  else step => step \\ divisions < equave >;
+  else step => step \\ divisions ed equave;
 }
 
 riff rank2(generator, up, down = 0, period = 2, numPeriods = 1) {
@@ -2595,7 +2595,7 @@ riff vao(denominator, maxNumerator, divisions = 12, tolerance = 5.0, equave = 2)
 
 riff concordanceShell(denominator, maxNumerator, divisions = 12, tolerance = 5.0, equave = 2) {
   "Generate a concordance shell i.e. a vertically aligned object reduced to an equal temperament. Intervals are labeled by their harmonics.";
-  let step = 1 \\ divisions <equave>;
+  let step = 1 \\ divisions ed equave;
   if (equave === 2) {
     step = 1 \\ divisions;
   }
@@ -2827,7 +2827,7 @@ riff equalize(divisions, scale = $$) {
   $ = scale;
   let step = 1 \\ divisions;
   if ($[-1] != 2)
-    step = step <$[-1]>;
+    step ed= $[-1];
   i => i by~ step colorOf(i) labelOf(i);
   return;
 }

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -264,7 +264,7 @@ export class Interval {
   project(base: Interval) {
     const node = projectNodes(this.node, base.node);
     return new Interval(
-      base.value.pow(this.value.octaves),
+      this.value.project(base.value),
       'logarithmic',
       node,
       infect(this, base)

--- a/src/monzo.ts
+++ b/src/monzo.ts
@@ -1284,6 +1284,15 @@ export class TimeMonzo {
   }
 
   /**
+   * Project the exponent of two to the given base.
+   * @param base New base to replace prime two.
+   * @returns N steps of equal divisions of the new base assuming this time monzo was N steps of an equally divided octave.
+   */
+  project(base: TimeMonzo) {
+    return base.pow(this.octaves);
+  }
+
+  /**
    * Check for strict equality between this and another time monzo.
    * @param other Another time monzo.
    * @returns `true` if the time monzos share the same time exponent, prime exponents, residual and cents offset.


### PR DESCRIPTION
Add more tiers of operator precedence.
Make rounding operators bind looser than harmonic segments. Make min and max bind looser than addition.
Rename stdlib 'ed' to 'tet' to avoid the now-reserved word.

ref #86