### PR TITLE
Implement records

### DIFF
--- a/BUILTIN.md
+++ b/BUILTIN.md
@@ -84,6 +84,9 @@ Remove intervals from the given/current scale that evaluate to `false` according
 ### doc(*riff*)
 Obtain the docstring of the given riff.
 
+### entries(*record*)
+Obtain an array of `[key, value]` pairs of the record.
+
 ### equaveOf(*val*)
 Return the equave of the val.
 
@@ -479,6 +482,9 @@ Convert interval to (relative) FJS using HEJI comma flavors.
 ### hypot(*...args*)
 Calculate the square root of the sum of squares of the arguments.
 
+### keys(*record*)
+Obtain an array of keys of the record.
+
 ### label(*labels*, *scale = $$*)
 Apply labels (or colors) from the first array to the current/given scale. Can also apply a single color to the whole scale.
 
@@ -682,6 +688,9 @@ Unstack the current/given scale into steps.
 
 ### unstacked(*array*)
 Calculate the relative steps in the current/given scale.
+
+### values(*record*)
+Obtain an array of values of the record.
 
 ### vao(*denominator*, *maxNumerator*, *divisions = 12*, *tolerance = 5.0*, *equave = 2*)
 Generate a vertically aligned object i.e. a subset of the harmonic series that sounds like the given equal temperament (default `12`) within the given tolerance (default `5c`). Harmonics equated by the `equave` (default `2/1`) are only included once. The returned segment begins at unison.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ SonicWeave comes with some basic types.
 | Color    | `#ff00ff`                | CSS colors, short hexadecimal, and long hexadecimal colors supported. Used for note colors. |
 | Boolean  | `true` or `false`        | Converted to `1` or `0` in scales. |
 | Interval | `7/5`                    | There are many types of intervals with their own operator semantics. |
-| Scale    | `[5/4, P5, 9\9]`         | Musical scales are represented using arrays of intervals. |
+| Array    | `[5/4, P5, 9\9]`         | Musical scales are represented using arrays of intervals. |
+| Record   | `{fif: 3/2, "p/e": 2}`   | Associative data indexed by strings. |
 | Function | `riff plusOne(x) {x+1}`  | _Riff_ is a music term for a short repeated phrase. |
 
 ### Basic interval types
@@ -233,6 +234,14 @@ Range syntax inside array access gets a copy of a subset the array e.g. `[1, 2, 
 
 In slice syntax the end points are optional e.g. `[1, 2, 3][..]` evaluates to `[1, 2, 3]` (a new copy).
 
+## Records
+Record literals are constructed using `key: value` pairs inside curly brackets e.g. `{fif: 3/2, "my octave": 2/1}`.
+
+### Record access
+Records are accessed with the same syntax as arrays but using string indices e.g. `{fif: 3/2}["fif"]` evaluates to `3/2`.
+
+Nullish access is supported e.g. `{}~["nothing here"]` evaluates to `niente`.
+
 ## Metric prefixes
 Frequency literals support [metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix) e.g. `1.2 kHz` is the same as `1200 Hz`.
 
@@ -399,13 +408,22 @@ while (--i) {
 results in `$ = [4, 3, 2, 1]`.
 
 ## For...of
-"For" loops iterate over array contents e.g.
+"For..of" loops iterate over array contents or record values e.g.
 ```javascript
 for (const i of [1..5]) {
   2 ^ (i % 5)
 }
 ```
 results in `$ = [2^1/5, 2^2/5, 2^3/5, 2^4/5, 2]`.
+
+## For..in
+"For..in" loops iterate over array indices or record keys e.g.
+```javascript
+for (const k in {a: 123, b: 456}) {
+  1 k
+}
+```
+results in `$ = [1 "b", 1 "a"]`. The order is indeterministic.
 
 ## Break
 "While" and "for" loops can be broken out of using the `break` keyword.

--- a/src/__tests__/parser/expression.spec.ts
+++ b/src/__tests__/parser/expression.spec.ts
@@ -1575,4 +1575,78 @@ describe('SonicWeave expression evaluator', () => {
     const tooSplit = parseSingle('P5 % 16');
     expect(tooSplit.toString()).toBe('1\\16<3/2>');
   });
+
+  it('has record syntax', () => {
+    const record = evaluateExpression(
+      '{foo: "a", "bar": "b", "here be spaces": "c"}',
+      false
+    );
+    expect(record).toEqual({bar: 'b', 'here be spaces': 'c', foo: 'a'});
+  });
+
+  it('has record access', () => {
+    const fif = parseSingle('{foo: 3/2}["foo"]');
+    expect(fif.toString()).toBe('3/2');
+  });
+
+  it('has the empty record', () => {
+    const blank = evaluateExpression('{}', false);
+    expect(blank).toEqual({});
+  });
+
+  it('has nullish record access', () => {
+    const nothing = evaluateExpression('{}~["zero nothings"]', false);
+    expect(nothing).toBe(undefined);
+  });
+
+  it('is resistant to pathological JS record keys', () => {
+    expect(() => evaluateExpression('{}["toString"]', false)).toThrow(
+      'Key error.'
+    );
+  });
+
+  it('has string representation of records', () => {
+    const str = evaluateExpression('str({foo: 1})', false);
+    expect(str).toBe('{"foo": 1}');
+  });
+
+  it('can assign record keys', () => {
+    const record = evaluateExpression(
+      'const rec = {foo: "a"};rec["bar"] = "b";rec',
+      false
+    );
+    expect(record).toEqual({foo: 'a', bar: 'b'});
+  });
+
+  it('can re-assign record values', () => {
+    const record = evaluateExpression(
+      'const rec = {foo: 1, bar: 2};rec["bar"] *= 3; rec',
+      false
+    ) as Record<string, Interval>;
+    expect(record['foo'].toString()).toBe('1');
+    expect(record['bar'].toString()).toBe('6');
+  });
+
+  it('can get the entries of a record', () => {
+    const entries = evaluateExpression(
+      'entries({foo: "a", bar: "b"})',
+      false
+    ) as unknown as [string, string][];
+    entries.sort((a, b) => a[1].localeCompare(b[1]));
+    expect(entries).toEqual([
+      ['foo', 'a'],
+      ['bar', 'b'],
+    ]);
+  });
+
+  it('can test for presence of keys in a record', () => {
+    const yes = evaluateExpression('"foo" in {foo: 1}');
+    expect(yes).toBe(true);
+  });
+
+  it('has a record shorthand', () => {
+    const record = evaluateExpression('const foo = "a";{foo}');
+    const foo = 'a';
+    expect(record).toEqual({foo});
+  });
 });

--- a/src/__tests__/parser/source.spec.ts
+++ b/src/__tests__/parser/source.spec.ts
@@ -1206,4 +1206,13 @@ describe('SonicWeave parser', () => {
       '12\\12',
     ]);
   });
+
+  it('has inline labels for ordered scales using records', () => {
+    const scale = parseSource('{third: 6/5, "The Octave": 2/1, fif: 3/2};repr');
+    expect(scale).toEqual([
+      '(6/5 "third")',
+      '(3/2 "fif")',
+      '(2/1 "The Octave")',
+    ]);
+  });
 });

--- a/src/__tests__/parser/stdlib.spec.ts
+++ b/src/__tests__/parser/stdlib.spec.ts
@@ -1221,4 +1221,16 @@ describe('SonicWeave standard library', () => {
       '2',
     ]);
   });
+
+  it('can get the keys of a record', () => {
+    const keys = evaluateExpression('keys({foo: 1, bar: 2})') as string[];
+    keys.sort();
+    expect(keys).toEqual(['bar', 'foo']);
+  });
+
+  it('can get the values of a record', () => {
+    const keys = evaluateExpression('values({foo: "a", bar: "b"})') as string[];
+    keys.sort();
+    expect(keys).toEqual(['a', 'b']);
+  });
 });

--- a/src/__tests__/sonic-weave-ast.spec.ts
+++ b/src/__tests__/sonic-weave-ast.spec.ts
@@ -314,15 +314,15 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
     expect(ast).toEqual({
       type: 'ExpressionStatement',
       expression: {
-        type: 'ArrayAccess',
+        type: 'AccessExpression',
         object: {
-          type: 'ArrayAccess',
+          type: 'AccessExpression',
           object: {type: 'Identifier', id: 'x'},
           nullish: false,
-          index: {type: 'Identifier', id: 'i'},
+          key: {type: 'Identifier', id: 'i'},
         },
         nullish: true,
-        index: {type: 'IntegerLiteral', value: 2n},
+        key: {type: 'IntegerLiteral', value: 2n},
       },
     });
   });
@@ -332,7 +332,7 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
     expect(ast).toEqual({
       type: 'ExpressionStatement',
       expression: {
-        type: 'ArrayAccess',
+        type: 'AccessExpression',
         nullish: false,
         object: {
           type: 'ArraySlice',
@@ -347,7 +347,7 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
           second: null,
           end: {type: 'IntegerLiteral', value: 2n},
         },
-        index: {type: 'IntegerLiteral', value: 0n},
+        key: {type: 'IntegerLiteral', value: 0n},
       },
     });
   });
@@ -358,9 +358,10 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
       type: 'Program',
       body: [
         {
-          type: 'ForOfStatement',
+          type: 'IterationStatement',
           element: {type: 'Parameter', id: 'foo', defaultValue: null},
-          array: {type: 'Identifier', id: 'bar'},
+          kind: 'of',
+          container: {type: 'Identifier', id: 'bar'},
           body: {
             type: 'ExpressionStatement',
             expression: {type: 'Identifier', id: 'foo'},
@@ -422,10 +423,10 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
     expect(ast).toEqual({
       type: 'AssignmentStatement',
       name: {
-        type: 'ArrayAccess',
+        type: 'AccessExpression',
         object: {type: 'Identifier', id: 'arr'},
         nullish: false,
-        index: {type: 'IntegerLiteral', value: 1n},
+        key: {type: 'IntegerLiteral', value: 1n},
       },
       value: {type: 'IntegerLiteral', value: 2n},
     });
@@ -438,10 +439,10 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
       expression: {
         type: 'CallExpression',
         callee: {
-          type: 'ArrayAccess',
+          type: 'AccessExpression',
           object: {type: 'Identifier', id: 'arr'},
           nullish: false,
-          index: {type: 'IntegerLiteral', value: 1n},
+          key: {type: 'IntegerLiteral', value: 1n},
         },
         args: [],
       },
@@ -455,7 +456,7 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
       expression: {
         type: 'CallExpression',
         callee: {
-          type: 'ArrayAccess',
+          type: 'AccessExpression',
           nullish: false,
           object: {
             type: 'ArraySlice',
@@ -464,7 +465,7 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
             second: null,
             end: null,
           },
-          index: {type: 'IntegerLiteral', value: 1n},
+          key: {type: 'IntegerLiteral', value: 1n},
         },
         args: [],
       },
@@ -671,7 +672,7 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
           for
             foo of baz
           for
-            bar of qux
+            bar in qux
       ]
     `);
     expect(ast).toEqual({
@@ -686,11 +687,13 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
         comprehensions: [
           {
             element: {type: 'Parameter', id: 'foo', defaultValue: null},
-            array: {type: 'Identifier', id: 'baz'},
+            kind: 'of',
+            container: {type: 'Identifier', id: 'baz'},
           },
           {
             element: {type: 'Parameter', id: 'bar', defaultValue: null},
-            array: {type: 'Identifier', id: 'qux'},
+            kind: 'in',
+            container: {type: 'Identifier', id: 'qux'},
           },
         ],
         test: null,
@@ -710,7 +713,7 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
 
   it('accepts array access spanning multiple rows', () => {
     const ast = parseSingle('foo[\nbar\n]');
-    expect(ast.expression.type).toBe('ArrayAccess');
+    expect(ast.expression.type).toBe('AccessExpression');
   });
 
   it('accepts array slice spanning multiple rows', () => {
@@ -865,10 +868,10 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
     expect(ast).toEqual({
       type: 'ExpressionStatement',
       expression: {
-        type: 'ArrayAccess',
+        type: 'AccessExpression',
         object: {type: 'Identifier', id: 'foo'},
         nullish: false,
-        index: {
+        key: {
           type: 'ArrayLiteral',
           elements: [
             {
@@ -883,6 +886,20 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
             },
           ],
         },
+      },
+    });
+  });
+
+  it('parses record literals', () => {
+    const ast = parseSingle('{foo: 1, "bar": 2}');
+    expect(ast).toEqual({
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'RecordLiteral',
+        properties: [
+          ['bar', {type: 'IntegerLiteral', value: 2n}],
+          ['foo', {type: 'IntegerLiteral', value: 1n}],
+        ],
       },
     });
   });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -16,6 +16,10 @@ export type BinaryOperator =
   | 'not of'
   | '~of'
   | 'not ~of'
+  | 'in'
+  | 'not in'
+  | '~in'
+  | 'not ~in'
   | '+'
   | '-'
   | 'max'
@@ -45,6 +49,8 @@ export type BinaryOperator =
   | '^'
   | '/^'
   | '^/';
+
+export type IterationKind = 'in' | 'of';
 
 export type Program = {
   type: 'Program';
@@ -76,7 +82,7 @@ export type EmptyStatement = {
 
 export type AssignmentStatement = {
   type: 'AssignmentStatement';
-  name: Identifier | Identifiers | ArrayAccess | ArraySlice;
+  name: Identifier | Identifiers | AccessExpression | ArraySlice;
   value: Expression;
 };
 
@@ -148,10 +154,11 @@ export type IfStatement = {
   alternate?: Statement;
 };
 
-export type ForOfStatement = {
-  type: 'ForOfStatement';
+export type IterationStatement = {
+  type: 'IterationStatement';
   element: Parameter | Parameters_;
-  array: Expression;
+  kind: IterationKind;
+  container: Expression;
   body: Statement;
   tail: null | Statement;
   mutable: boolean;
@@ -187,7 +194,7 @@ export type Statement =
   | BlockStatement
   | WhileStatement
   | IfStatement
-  | ForOfStatement
+  | IterationStatement
   | TryStatement
   | ThrowStatement
   | BreakStatement
@@ -207,11 +214,11 @@ export type ConditionalExpression = {
   alternate: Expression;
 };
 
-export type ArrayAccess = {
-  type: 'ArrayAccess';
+export type AccessExpression = {
+  type: 'AccessExpression';
   object: Expression;
   nullish: boolean;
-  index: Expression;
+  key: Expression;
 };
 
 export type ArraySlice = {
@@ -306,7 +313,8 @@ export type Range = {
 
 export type Comprehension = {
   element: Parameter | Parameters_;
-  array: Expression;
+  kind: IterationKind;
+  container: Expression;
 };
 
 export type ArrayComprehension = {
@@ -319,6 +327,11 @@ export type ArrayComprehension = {
 export type ArrayLiteral = {
   type: 'ArrayLiteral';
   elements: Argument[];
+};
+
+export type RecordLiteral = {
+  type: 'RecordLiteral';
+  properties: [string, Expression][];
 };
 
 export type StringLiteral = {
@@ -337,7 +350,7 @@ export type FalseLiteral = {
 export type Expression =
   | LestExpression
   | ConditionalExpression
-  | ArrayAccess
+  | AccessExpression
   | ArraySlice
   | UnaryExpression
   | DownExpression
@@ -355,6 +368,7 @@ export type Expression =
   | Range
   | ArrayComprehension
   | ArrayLiteral
+  | RecordLiteral
   | StringLiteral
   | HarmonicSegment;
 


### PR DESCRIPTION
Include records in the type hierarchy.
Clarify the array type.
Interprete top-level records as labeled scales.
Implement record literal syntax.
Add support for record access.
Implement builtin for record entries.
Implement stdlib for record keys and values.

ref #197