### PR TITLE
Make tagged template argument handling less janky

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ You can read more about domains and echelons [below](#interval-type-system).
 | Integer      | `2`, `5`                | Linear        | Relative | Same as `2/1` or `5/1`. |
 | Decimal      | `1,2`, `1.4e0`          | Linear        | Relative | Decimal commas only work in isolation. |
 | Fraction     | `4/3`, `10/7`           | Linear        | Relative | |
-| N-of-EDO     | `1\5`, `7\12`           | Logarithmic   | Relative | `n\m` means `n` steps of `m` equal divisions of the octave `2/1`. |
+| N-of-EDO     | `1\5`, `7\12`, `7°12`   | Logarithmic   | Relative | `n\m` means `n` steps of `m` equal divisions of the octave `2/1`. |
 | N-of-EDJI    | `9\13<3>`, `2\5<3/2>`   | Logarithmic   | Relative | `n\m<p/q>` means `n` steps of `m` equal divisions of the ratio `p/q`. |
-| Step         | `7\`, `13\`             | Logarithmic   | Relative | Correspond to edo-steps after tempering is applied. |
+| Step         | `7\`, `13\`, `13°`      | Logarithmic   | Relative | Correspond to edo-steps after tempering is applied. |
 | Cents        | `701.955`, `100c`       | Logarithmic   | Relative | One centisemitone `1.0` is equal to `1\1200`. |
 | Monzo        | `[-4 4 -1>`, `[1,-1/2>` | Logarithmic   | Relative | Also known as prime count vectors. Each component is an exponent of a prime number factor. |
 | FJS          | `P5`, `M3^5`            | Logarithmic   | Relative | [Functional Just System](https://en.xen.wiki/w/Functional_Just_System) |
@@ -36,6 +36,8 @@ You can read more about domains and echelons [below](#interval-type-system).
 | S-expression | `S8`, `S5..8`           | Logarithmic   | Relative | Additive spelling of [square superparticulars](https://en.xen.wiki/w/Square_superparticular). |
 | Val          | `<12, 19, 28]`          | Cologarithmic | Relative | Used to temper scales. |
 | Warts        | `12@`, `29@2.3.13/5`    | Cologarithmic | Relative | [Shorthand](https://en.xen.wiki/w/Val#Shorthand_notation) for vals. |
+
+The `n°m` (n degrees of m edo) alternative exists to avoid using the backslash inside tagged template literals.
 
 #### Numeric separators
 It is possible to separate numbers into groups using underscores for readability e.g. `1_000_000` is one million as an integer and `123_201/123_200` is the [chalmerisia](https://en.xen.wiki/w/Chalmersia) as a fraction.
@@ -115,6 +117,8 @@ SonicWeave comes with some operators.
 
 Down-shimmer sometimes requires curly brackets due to `v` colliding with the Latin alphabet.
 
+Drop `\` can be spelled `drop` to avoid using the backslash inside template literals. Lift `/` may be spelled `lift` for minor grammatical reasons.
+
 Increment/decrement assumes that you've declared `let i = 2` originally.
 ### Coalescing
 | Name               | Example       | Result |
@@ -186,6 +190,7 @@ Outer product a.k.a. tensoring expands all possible products in two arrays into 
 | Logarithm (in base of) | `9 /_ 3`       | `2`      | `M23 % P12`      | `2`        |
 | Round (to power of)    | `5 by 2`       | `4`      | `M17^5 to P8`    | `P15`      |
 | N of EDO               | `(5+2)\12`     | `7\12`   | _N/A_            |            |
+| N of EDO               | `(5+2)°12`     | `7\12`   | _N/A_            |            |
 | NEDJI Projection       | `sqrt(2) ed 3` | `1\2<3>` | `2\3 ed S3`      | `2\3<9/8>` |
 | Val product            | `12@ · 3/2`    | `7`      | `<12 19] dot P5` | `7`        |
 

--- a/src/__tests__/parser/expression.spec.ts
+++ b/src/__tests__/parser/expression.spec.ts
@@ -1757,4 +1757,11 @@ describe('SonicWeave expression evaluator', () => {
     expect(tooLong.isAbsolute()).toBe(true);
     expect(tooLong.valueOf()).toBeCloseTo(3 * 1024 ** 8);
   });
+
+  it('has a "lift" operator because the template tag requires a "drop" operator, but I guess it is useful for enumerated chords where mirroring would take precedence...', () => {
+    const rootLift = evaluateExpression('lift 4:5:6', false) as Interval[];
+    expect(rootLift).toHaveLength(2);
+    expect(rootLift[0].valueOf()).toBe(1.2463950666682366);
+    expect(rootLift[1].valueOf()).toBe(1.4956740800018837);
+  });
 });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,5 +1,19 @@
 import {IntervalLiteral, literalToString} from './expression';
 
+export type UnaryOperator =
+  | '+'
+  | '-'
+  | '%'
+  | '÷'
+  | 'not'
+  | '^'
+  | '/'
+  | 'lift'
+  | '\\'
+  | 'drop'
+  | '++'
+  | '--';
+
 export type BinaryOperator =
   | '??'
   | 'or'
@@ -36,6 +50,7 @@ export type BinaryOperator =
   | '%'
   | '÷'
   | '\\'
+  | '°'
   | 'mod'
   | 'modc'
   | 'rd'
@@ -232,7 +247,7 @@ export type ArraySlice = {
 
 export type UnaryExpression = {
   type: 'UnaryExpression';
-  operator: '+' | '-' | '%' | '÷' | 'not' | '^' | '/' | '\\' | '++' | '--';
+  operator: UnaryOperator;
   operand: Expression;
   prefix: boolean;
   uniform: boolean;
@@ -271,6 +286,11 @@ export type ColorLiteral = {
 export type Identifier = {
   type: 'Identifier';
   id: string;
+};
+
+export type TemplateArgument = {
+  type: 'TemplateArgument';
+  index: number;
 };
 
 export type Argument = {
@@ -365,6 +385,7 @@ export type Expression =
   | FalseLiteral
   | ColorLiteral
   | Identifier
+  | TemplateArgument
   | EnumeratedChord
   | Range
   | ArrayComprehension
@@ -409,6 +430,8 @@ export function expressionToString(node: Expression) {
       return 'niente';
     case 'Identifier':
       return node.id;
+    case 'TemplateArgument':
+      return `£${node.index}`;
     case 'StringLiteral':
       return JSON.stringify(node.value);
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,4 @@
+import {SonicWeaveValue} from './builtin';
 import {Val, type Interval} from './interval';
 import {TimeMonzo} from './monzo';
 import {ZERO} from './utils';
@@ -11,6 +12,7 @@ export class RootContext {
   gas: number;
   fragiles: (Interval | Val)[];
   trackingIndex: number;
+  templateArguments: SonicWeaveValue[];
 
   constructor(gas?: number) {
     this.title = '';
@@ -20,6 +22,7 @@ export class RootContext {
     this.gas = gas ?? Infinity;
     this.fragiles = [];
     this.trackingIndex = 0;
+    this.templateArguments = [];
   }
 
   get C4() {

--- a/src/sonic-weave.pegjs
+++ b/src/sonic-weave.pegjs
@@ -55,6 +55,7 @@ CatchToken         = 'catch'    !IdentifierPart
 ConstToken         = 'const'    !IdentifierPart
 ContinueToken      = 'continue' !IdentifierPart
 DotToken           = 'dot'      !IdentifierPart
+DropToken          = 'drop'     !IdentifierPart
 EdToken            = 'ed'       !IdentifierPart
 ElseToken          = 'else'     !IdentifierPart
 FalseToken         = 'false'    !IdentifierPart
@@ -64,6 +65,7 @@ IfToken            = 'if'       !IdentifierPart
 InToken            = 'in'       !IdentifierPart
 LestToken          = 'lest'     !IdentifierPart
 LetToken           = 'let'      !IdentifierPart
+LiftToken          = 'lift'     !IdentifierPart
 MaxToken           = 'max'      !IdentifierPart
 MinToken           = 'min'      !IdentifierPart
 ModToken           = 'mod'      !IdentifierPart
@@ -92,6 +94,7 @@ ReservedWord
   / ConstToken
   / ContinueToken
   / DotToken
+  / DropToken
   / EdToken
   / ElseToken
   / FalseToken
@@ -100,6 +103,7 @@ ReservedWord
   / InToken
   / LestToken
   / LetToken
+  / LiftToken
   / MaxToken
   / MinToken
   / ModToken
@@ -255,7 +259,7 @@ UpDeclaration
   }
 
 LiftDeclaration
-  = '/' _ '=' _ value: Expression EOS {
+  = ('/' / LiftToken) _ '=' _ value: Expression EOS {
     return {
       type: 'LiftDeclaration',
       value,
@@ -617,7 +621,7 @@ Term
   }
 
 MultiplicativeOperator
-  = $('*' / '×' / '%' / '÷' / '\\' / '·' / DotToken / '⊗' / TensorToken)
+  = $('*' / '×' / '%' / '÷' / '\\' / '°' / '·' / DotToken / '⊗' / TensorToken)
 
 MultiplicativeExpression
   = head: UniformUnaryExpression tail: (__ @'~'? @MultiplicativeOperator @'~'? _ @UniformUnaryExpression)* {
@@ -673,7 +677,7 @@ FractionExpression
   }
 
 Labels
-  = (CallExpression / TrueAccessExpression / Identifier / ColorLiteral / StringLiteral / NoneLiteral)|1.., __|
+  = (CallExpression / TrueAccessExpression / Identifier / TemplateArgument / ColorLiteral / StringLiteral / NoneLiteral)|1.., __|
 
 // XXX: Don't know why that trailing __ has to be there.
 LabeledExpression
@@ -705,7 +709,7 @@ Secondary
   / AccessExpression
 
 ChainableUnaryOperator
-  = $NotToken / '^' / '/' / '\\'
+  = $(NotToken / '^' / '/' / LiftToken / '\\' / DropToken)
 
 UnaryExpression
   = operator: UniformUnaryOperator uniform: '~'? operand: Secondary {
@@ -858,6 +862,7 @@ Primary
   / AbsoluteFJS
   / SquareSuperparticular
   / Identifier
+  / TemplateArgument
   / ArrayLiteral
   / RecordLiteral
   / StringLiteral
@@ -912,7 +917,7 @@ DownExpression
   }
 
 StepLiteral
-  = count: BasicInteger '\\' __ denominator: (ParenthesizedExpression / CallExpression / TrueAccessExpression / Identifier)? {
+  = count: BasicInteger ('\\' / '°') __ denominator: (ParenthesizedExpression / CallExpression / TrueAccessExpression / Identifier / TemplateArgument)? {
     if (denominator) {
       return BinaryExpression(
         '\\',
@@ -932,7 +937,7 @@ StepLiteral
   }
 
 NedjiLiteral
-  = numerator: BasicInteger '\\' denominator: PositiveBasicInteger '<' equaveNumerator: PositiveBasicInteger equaveDenominator: ('/' @PositiveBasicInteger)? '>' {
+  = numerator: BasicInteger ('\\' / '°') denominator: PositiveBasicInteger '<' equaveNumerator: PositiveBasicInteger equaveDenominator: ('/' @PositiveBasicInteger)? '>' {
     return {
       type: 'NedjiLiteral',
       numerator,
@@ -941,7 +946,7 @@ NedjiLiteral
       equaveDenominator,
     };
   }
-  / numerator: BasicInteger '\\' denominator: PositiveBasicInteger {
+  / numerator: BasicInteger ('\\' / '°') denominator: PositiveBasicInteger {
     return {
       type: 'NedjiLiteral',
       numerator,
@@ -1373,6 +1378,14 @@ Identifier
     return {
       type: 'Identifier',
       id,
+    };
+  }
+
+TemplateArgument
+  = '£' index: BasicInteger {
+    return {
+      type: 'TemplateArgument',
+      index,
     };
   }
 


### PR DESCRIPTION
Add workarounds to JavaScript's poor handling of backslashes inside tagged template literals.