### PR TITLE
Remove lest-assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,10 +597,10 @@ try {
 ```
 
 ## Lest expressions
-The inline version of `try..catch` is called `lest`. The latter expression is tried and replaced by the former on failure.
+The inline version of `try..catch` is called `lest`. The former expression is tried and replaced by the latter on failure.
 ```javascript
-P5 lest fraction(P5) // Successfully evaluates to 3/2
-PI lest fraction(PI) // Falls back to 3.141592653589793r
+fraction(P5) lest P5 // Successfully evaluates to 3/2
+fraction(PI) lest PI // Falls back to 3.141592653589793r
 ```
 
 ## Implicit mapping

--- a/documentation/technical.md
+++ b/documentation/technical.md
@@ -26,7 +26,7 @@ The language is weakly typed and weakly valued. Logdivision is particularly leak
 
 The following table summarizes the operator precedence in SonicWeave, from highest precedence (most binding) to lowest precedence (least binding). Operators in the same box have the same precedence.
 
-All operations are left-associative except exponentiation, recipropower, logdivision and fallback (marked with an asterisk *).
+All operations are left-associative except exponentiation, recipropower, and logdivision (marked with an asterisk *).
 
 | Operator                                         | Description                                                             |
 | ------------------------------------------------ | ----------------------------------------------------------------------- |
@@ -51,7 +51,7 @@ All operations are left-associative except exponentiation, recipropower, logdivi
 | `and`, `vand`                                    | Boolean and, vector and                                                 |
 | `or`, `vor`, `??`                                | Boolean or, vector or, niente coalescing                                |
 | `x if y else z`                                  | Ternary conditional                                                     |
-| `lest`                                           | Fallback*                                                               |
+| `lest`                                           | Fallback                                                                |
 
 Parenthesis, `^`, `×`, `÷`, `+`, `-` follow [PEMDAS](https://en.wikipedia.org/wiki/Order_of_operations). The fraction slash `/` represents vertically aligned fractions similar to `$\frac{3}{2}^\frac{1}{2}$` in LaTeX e.g. `3/2 ^ 1/2` evaluates to `sqrt(3 ÷ 2)`.
 

--- a/src/parser/__tests__/expression.spec.ts
+++ b/src/parser/__tests__/expression.spec.ts
@@ -1455,25 +1455,25 @@ describe('SonicWeave expression evaluator', () => {
   });
 
   it('has inline analogue of try..catch (success)', () => {
-    const {interval} = parseSingle('[-1 1> lest fraction([-1 1>)');
+    const {interval} = parseSingle('fraction([-1 1>) lest [-1 1>');
     expect(interval.toString()).toBe('3/2');
   });
 
-  it('has inline analogue of try..catch (right success)', () => {
+  it('has inline analogue of try..catch (left success)', () => {
     const {interval} = parseSingle(
-      '[-1 1> lest fraction([-1 1>) lest fraction([1>)'
+      'fraction([1>) lest fraction([-1 1>) lest [-1 1>'
     );
     expect(interval.toString()).toBe('2/1');
   });
 
   it('has an inline analogue of try..catch (failure)', () => {
-    const pi = evaluate('PI lest fraction(PI)') as Interval;
+    const pi = evaluate('fraction(PI) lest PI') as Interval;
     expect(pi.value.isFractional()).toBe(false);
     expect(pi.valueOf()).toBeCloseTo(Math.PI);
   });
 
-  it('has an inline analogue of try..catch (left failure)', () => {
-    const pi = evaluate('PI lest fraction(PI) lest fraction(E)') as Interval;
+  it('has an inline analogue of try..catch (right failure)', () => {
+    const pi = evaluate('fraction(E) lest fraction(PI) lest PI') as Interval;
     expect(pi.value.isFractional()).toBe(false);
     expect(pi.valueOf()).toBeCloseTo(Math.PI);
   });
@@ -1483,6 +1483,8 @@ describe('SonicWeave expression evaluator', () => {
       'let halfTau = PI;halfTau lest= fraction(halfTau);halfTau'
     ) as Interval;
     expect(pi.value.isFractional()).toBe(false);
+    expect(pi.value.isFractional()).toBe(false);
+    expect(pi.valueOf()).toBeCloseTo(Math.PI);
     expect(pi.valueOf()).toBeCloseTo(Math.PI);
   });
 

--- a/src/parser/__tests__/sonic-weave-ast.spec.ts
+++ b/src/parser/__tests__/sonic-weave-ast.spec.ts
@@ -988,28 +988,6 @@ describe('SonicWeave Abstract Syntax Tree parser', () => {
     });
   });
 
-  it('has a right-associative lest', () => {
-    const ast = parseSingle('foo lest bar lest baz');
-    expect(ast).toEqual({
-      type: 'ExpressionStatement',
-      expression: {
-        type: 'BinaryExpression',
-        operator: 'lest',
-        left: {type: 'Identifier', id: 'foo'},
-        right: {
-          type: 'BinaryExpression',
-          operator: 'lest',
-          left: {type: 'Identifier', id: 'bar'},
-          right: {type: 'Identifier', id: 'baz'},
-          preferLeft: false,
-          preferRight: false,
-        },
-        preferLeft: false,
-        preferRight: false,
-      },
-    });
-  });
-
   it('has a ternary operator complex with pythonic associativity', () => {
     const ast = parseSingle('foo if bar else baz where qux else quux');
     expect(ast).toEqual({

--- a/src/parser/__tests__/source.spec.ts
+++ b/src/parser/__tests__/source.spec.ts
@@ -963,7 +963,7 @@ describe('SonicWeave parser', () => {
       9/8
       E % 2r
       G4
-      i => i lest FJS(i)
+      i => FJS(i) lest i
     `);
     expect(scale).toEqual(['M2', '1.3591409142295225r', 'P5']);
   });

--- a/src/parser/expression.ts
+++ b/src/parser/expression.ts
@@ -1534,9 +1534,9 @@ export class ExpressionVisitor {
     const operator = node.operator;
     if (operator === 'lest') {
       try {
-        return this.visit(node.right);
-      } catch {
         return this.visit(node.left);
+      } catch {
+        return this.visit(node.right);
       }
     }
     const left = this.visit(node.left);


### PR DESCRIPTION
`x lest= y` means `x` becomes `y` if `x` fails and is `x` if `x` succeeds, thus it's not very useful.