### PR TITLE
Simplify public built-in call signatures

### DIFF
--- a/src/__tests__/context.spec.ts
+++ b/src/__tests__/context.spec.ts
@@ -1,0 +1,27 @@
+import {describe, it, expect} from 'vitest';
+import {RootContext} from '../context';
+
+const SERIALIZED =
+  '{"num":7,"str":"hi","context":{"type":"RootContext","title":"","unisonFrequency":null,"C4":{"type":"TimeMonzo","t":{"n":0,"d":1},"p":[],"r":{"n":1,"d":1}},"up":{"type":"Interval","v":{"type":"TimeMonzo","t":{"n":0,"d":1},"p":[],"r":{"n":1,"d":1}},"d":1,"s":1,"l":"","t":[]},"lift":{"type":"Interval","v":{"type":"TimeMonzo","t":{"n":0,"d":1},"p":[],"r":{"n":1,"d":1}},"d":1,"s":5,"l":"","t":[]},"gas":null,"trackingIndex":0,"mosConfig":null}}';
+
+describe('Evaluation context', () => {
+  it('can be serialized alongside other data', () => {
+    const data = {
+      num: 7,
+      str: 'hi',
+      context: new RootContext(),
+    };
+    const serialized = JSON.stringify(data);
+    expect(serialized).toBe(SERIALIZED);
+  });
+
+  it('can be deserialized alongside other data', () => {
+    const data = JSON.parse(SERIALIZED, RootContext.reviver);
+    const context = data.context;
+    expect(data.num).toBe(7);
+    expect(data.str).toBe('hi');
+    expect(context.gas).toBe(Infinity);
+    expect(context.unisonFrequency).toBe(undefined);
+    expect(context.C4.isUnity()).toBe(true);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ export function toScalaScl(source: string) {
   const scale = visitor.mutables.get('$') as Interval[];
   lines.push(` ${scale.length}`);
   lines.push('!');
-  const rel = relative.bind(visitor as unknown as ExpressionVisitor);
+  const rel = relative.bind(visitor.rootContext);
   for (const interval of scale) {
     if (interval.color) {
       keyColors.push(interval.color.value);
@@ -180,7 +180,7 @@ export function repl(start: (options?: string | ReplOptions) => REPLServer) {
   start({
     prompt,
     eval: evaluateStatement,
-    writer: repr.bind(visitor.createExpressionVisitor()),
+    writer: repr.bind(visitor.rootContext),
     terminal: true,
     completer: () => [],
   });

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -30,7 +30,7 @@ import {
   CoIntervalLiteral,
   WartBasisElement,
 } from './expression';
-import {TimeMonzo, TimeReal, getNumberOfComponents} from './monzo';
+import {TimeMonzo, TimeReal, getNumberOfComponents, reviveMonzo} from './monzo';
 import {asAbsoluteFJS, asFJS} from './fjs';
 import {type RootContext} from './context';
 import {
@@ -301,14 +301,8 @@ export class Interval {
       value !== null &&
       value.type === 'Interval'
     ) {
-      let monzo: TimeMonzo | TimeReal;
-      if (value.v.type === 'TimeMonzo') {
-        monzo = TimeMonzo.reviver('value', value.v);
-      } else {
-        monzo = TimeReal.reviver('value', value.v);
-      }
       const result = new Interval(
-        monzo,
+        reviveMonzo(value.v),
         value.d ? 'logarithmic' : 'linear',
         value.s,
         intervalLiteralFromJSON(value.n)

--- a/src/monzo.ts
+++ b/src/monzo.ts
@@ -3018,3 +3018,19 @@ export class TimeMonzo {
     return literalToString(this.asValLiteral());
   }
 }
+
+/**
+ * Revive a serialized object produced by {@link TimeReal.toJSON} or {@link TimeMonzo.toJSON}.
+ * @param data Serialized JSON object.
+ * @returns Deserialized {@link TimeReal} or {@link TimeMonzo}.
+ */
+export function reviveMonzo(
+  data: ReturnType<TimeReal['toJSON']> | ReturnType<TimeMonzo['toJSON']>
+): TimeReal | TimeMonzo {
+  if (data.type === 'TimeReal') {
+    return TimeReal.reviver('value', data);
+  } else if (data.type === 'TimeMonzo') {
+    return TimeMonzo.reviver('value', data);
+  }
+  throw new Error(`Unrecognized monzo type '${data.type}'`);
+}

--- a/src/parser/__tests__/formatting.spec.ts
+++ b/src/parser/__tests__/formatting.spec.ts
@@ -22,7 +22,7 @@ function evaluate(source: string) {
   }
   const subVisitor = visitor.createExpressionVisitor();
   const result = subVisitor.visit(finalStatement.expression);
-  return repr.bind(subVisitor)(result);
+  return repr.bind(subVisitor.rootContext)(result);
 }
 
 describe('SonicWeave formatting semantics', () => {

--- a/src/parser/__tests__/source.spec.ts
+++ b/src/parser/__tests__/source.spec.ts
@@ -633,7 +633,7 @@ describe('SonicWeave parser', () => {
     for (const statement of userAst.body) {
       visitor.visit(statement);
     }
-    const r = relative.bind(visitor);
+    const r = relative.bind(visitor.rootContext);
     (visitor.get('$') as Interval[]).sort((a, b) => r(a).compare(r(b)));
     expect(visitor.expand(defaults)).toBe(
       [

--- a/src/parser/__tests__/stdlib.spec.ts
+++ b/src/parser/__tests__/stdlib.spec.ts
@@ -1093,7 +1093,7 @@ describe('SonicWeave standard library', () => {
       view.length = 0;
       const scale = this.currentScale;
       for (let i = 0; i < scale.length; ++i) {
-        scale[i] = track.bind(this)(scale[i]);
+        scale[i] = track.bind(this.rootContext)(scale[i]);
       }
       for (const interval of scale) {
         view.push(interval.value.toIntegerMonzo(true));

--- a/src/parser/expression.ts
+++ b/src/parser/expression.ts
@@ -667,7 +667,7 @@ export class ExpressionVisitor {
 
   protected visitRangeRelation(node: RangeRelation) {
     const tbc = ternaryBroadcast.bind(this);
-    const c = compare.bind(this);
+    const c = compare.bind(this.rootContext);
     const lop = node.leftOperator;
     const rop = node.rightOperator;
     function rr(
@@ -1376,11 +1376,15 @@ export class ExpressionVisitor {
               break;
             case 'max':
               value =
-                compare.bind(this)(left, right) >= 0 ? left.value : right.value;
+                compare.bind(this.rootContext)(left, right) >= 0
+                  ? left.value
+                  : right.value;
               break;
             case 'min':
               value =
-                compare.bind(this)(left, right) <= 0 ? left.value : right.value;
+                compare.bind(this.rootContext)(left, right) <= 0
+                  ? left.value
+                  : right.value;
               break;
             case 'to':
               value = left.value.roundTo(right.value);
@@ -1513,13 +1517,13 @@ export class ExpressionVisitor {
           case '~<>':
             return !left.equals(right);
           case '<=':
-            return compare.bind(this)(left, right) <= 0;
+            return compare.bind(this.rootContext)(left, right) <= 0;
           case '>=':
-            return compare.bind(this)(left, right) >= 0;
+            return compare.bind(this.rootContext)(left, right) >= 0;
           case '<':
-            return compare.bind(this)(left, right) < 0;
+            return compare.bind(this.rootContext)(left, right) < 0;
           case '>':
-            return compare.bind(this)(left, right) > 0;
+            return compare.bind(this.rootContext)(left, right) > 0;
           case '+':
             return left.add(right);
           case '-':
@@ -1553,9 +1557,13 @@ export class ExpressionVisitor {
           case 'rdc':
             return left.reduce(right, true);
           case 'max':
-            return compare.bind(this)(left, right) >= 0 ? left : right;
+            return compare.bind(this.rootContext)(left, right) >= 0
+              ? left
+              : right;
           case 'min':
-            return compare.bind(this)(left, right) <= 0 ? left : right;
+            return compare.bind(this.rootContext)(left, right) <= 0
+              ? left
+              : right;
           case 'to':
             return left.roundTo(right);
           case 'by':
@@ -1618,13 +1626,15 @@ export class ExpressionVisitor {
             }
           case 'tmpr':
             if (node.preferLeft) {
-              const value = (temper.bind(this)(right, left) as Interval).value;
+              const value = (
+                temper.bind(this.rootContext)(right, left) as Interval
+              ).value;
               const node = intervalValueAs(value, left.node);
               return new Interval(value, left.domain, 0, node, left);
             } else if (node.preferRight) {
               throw new Error('Cannot prefer the val operand when tempering.');
             }
-            return temper.bind(this)(right, left);
+            return temper.bind(this.rootContext)(right, left);
         }
         throw new Error(
           `Operator '${operator}' not implemented between intervals and vals.`
@@ -1712,13 +1722,15 @@ export class ExpressionVisitor {
             return left.dot(right);
           case 'tmpr':
             if (node.preferRight) {
-              const value = (temper.bind(this)(left, right) as Interval).value;
+              const value = (
+                temper.bind(this.rootContext)(left, right) as Interval
+              ).value;
               const node = intervalValueAs(value, right.node);
               return new Interval(value, right.domain, 0, node, right);
             } else if (node.preferLeft) {
               throw new Error('Cannot prefer the val operand when tempering.');
             }
-            return temper.bind(this)(left, right);
+            return temper.bind(this.rootContext)(left, right);
         }
         throw new Error(
           `Operator '${operator}' not implemented between vals and intervals.`

--- a/src/parser/statement.ts
+++ b/src/parser/statement.ts
@@ -224,7 +224,7 @@ export class StatementVisitor {
       base += '\n';
     }
     const variableLines: string[] = [];
-    const r = repr.bind(this.createExpressionVisitor());
+    const r = repr.bind(this.rootContext);
     for (const key of this.mutables.keys()) {
       if (key === '$' || key === '$$') {
         continue;
@@ -888,7 +888,7 @@ export class StatementVisitor {
   }
 
   protected freezeScale() {
-    const a = absolute.bind(this.createExpressionVisitor());
+    const a = absolute.bind(this.rootContext);
     const scale = this.currentScale;
     const frozen = scale.map(i => a(i));
     scale.length = 0;
@@ -1029,7 +1029,7 @@ export class StatementVisitor {
       scale.push(value);
     } else if (value instanceof Val) {
       this.spendGas(scale.length * value.value.numberOfComponents);
-      const mapped = temper.bind(subVisitor)(value, scale) as Interval[];
+      const mapped = temper.bind(this.rootContext)(value, scale) as Interval[];
       scale.length = 0;
       scale.push(...mapped);
     } else if (Array.isArray(value)) {

--- a/src/stdlib/builtin/index.ts
+++ b/src/stdlib/builtin/index.ts
@@ -354,7 +354,7 @@ function absolute(
 ): SonicWeaveValue {
   requireParameters({interval});
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    return pubAbsolute.bind(this)(interval);
+    return pubAbsolute.bind(this.rootContext)(interval);
   }
   return unaryBroadcast.bind(this)(interval, absolute.bind(this));
 }
@@ -368,7 +368,7 @@ function relative(
 ): SonicWeaveValue {
   requireParameters({interval});
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    return pubRelative.bind(this)(interval);
+    return pubRelative.bind(this.rootContext)(interval);
   }
   return unaryBroadcast.bind(this)(interval, relative.bind(this));
 }
@@ -395,7 +395,7 @@ function int(
     // XXX: JS semantics make '12.3' pass through here.
     return fromInteger(parseInt(interval, 10));
   } else if (typeof interval === 'boolean' || interval instanceof Interval) {
-    interval = pubRelative.bind(this)(upcastBool(interval));
+    interval = pubRelative.bind(this.rootContext)(upcastBool(interval));
     return Interval.fromInteger(interval.toInteger());
   }
   return unaryBroadcast.bind(this)(interval, int.bind(this));
@@ -417,7 +417,7 @@ function decimal(
   if (typeof interval === 'string') {
     interval = Interval.fromFraction(interval);
   }
-  const converted = pubRelative.bind(this)(upcastBool(interval));
+  const converted = pubRelative.bind(this.rootContext)(upcastBool(interval));
   if (fractionDigits !== undefined) {
     const denominator = 10 ** fractionDigits.toInteger();
     const numerator = Math.round(converted.value.valueOf() * denominator);
@@ -455,7 +455,7 @@ function fraction(
   const denominator = preferredDenominator
     ? upcastBool(preferredDenominator).value.toBigInteger()
     : 0n;
-  const converted = pubRelative.bind(this)(upcastBool(interval));
+  const converted = pubRelative.bind(this.rootContext)(upcastBool(interval));
   let value: TimeMonzo;
   if (tolerance === undefined) {
     if (converted.value instanceof TimeReal) {
@@ -502,7 +502,7 @@ function radical(
     // XXX: Technically missing radical literal parsing.
     interval = Interval.fromFraction(interval);
   }
-  const converted = pubRelative.bind(this)(upcastBool(interval));
+  const converted = pubRelative.bind(this.rootContext)(upcastBool(interval));
   const maxIdx = maxIndex ? upcastBool(maxIndex).toInteger() : undefined;
   if (converted.value.isEqualTemperament()) {
     const node = converted.value.asRadicalLiteral();
@@ -679,7 +679,7 @@ function cents(
     const monzo = TimeMonzo.fromFractionalCents(interval);
     interval = new Interval(monzo, 'logarithmic');
   }
-  const converted = pubRelative.bind(this)(upcastBool(interval));
+  const converted = pubRelative.bind(this.rootContext)(upcastBool(interval));
   if (fractionDigits !== undefined) {
     const denominator = 10 ** fractionDigits.toInteger();
     try {
@@ -745,9 +745,9 @@ function absoluteFJS(
   const C4 = this.rootContext.C4;
   let monzo: TimeMonzo | TimeReal;
   if (C4.timeExponent.n === 0) {
-    monzo = pubRelative.bind(this)(interval).value;
+    monzo = pubRelative.bind(this.rootContext)(interval).value;
   } else {
-    monzo = pubAbsolute.bind(this)(interval).value;
+    monzo = pubAbsolute.bind(this.rootContext)(interval).value;
   }
   const result = new Interval(monzo, 'logarithmic', interval.steps, {
     type: 'AspiringAbsoluteFJS',
@@ -783,7 +783,7 @@ function FJS(
     throw new Error('String parsing of FJS not implemented yet.');
   }
   interval = upcastBool(interval);
-  const monzo = pubRelative.bind(this)(interval).value;
+  const monzo = pubRelative.bind(this.rootContext)(interval).value;
   const result = new Interval(monzo, 'logarithmic', interval.steps, {
     type: 'AspiringFJS',
     flavor: validateFlavor(flavor),
@@ -1216,7 +1216,7 @@ fromCodePoint.__node__ = builtinNode(fromCodePoint);
 // == Other ==
 
 function track(this: ExpressionVisitor, interval: SonicWeaveValue) {
-  return pubTrack.bind(this)(upcastBool(interval));
+  return pubTrack.bind(this.rootContext)(upcastBool(interval));
 }
 track.__doc__ = 'Attach a tracking ID to the interval.';
 track.__node__ = builtinNode(track);
@@ -1297,7 +1297,7 @@ function JIP(
     return unaryBroadcast.bind(this)(interval, JIP.bind(this));
   }
   interval = upcastBool(interval);
-  const monzo = pubRelative.bind(this)(interval).value;
+  const monzo = pubRelative.bind(this.rootContext)(interval).value;
   if (monzo instanceof TimeReal) {
     return new Interval(monzo, 'logarithmic', 0, undefined, interval);
   }
@@ -1320,7 +1320,7 @@ function real(
   } else if (interval === false) {
     return new Interval(TimeReal.fromValue(0), 'linear');
   } else if (interval instanceof Interval) {
-    interval = pubRelative.bind(this)(interval);
+    interval = pubRelative.bind(this.rootContext)(interval);
     return new Interval(TimeReal.fromValue(interval.valueOf()), 'linear');
   }
   return unaryBroadcast.bind(this)(interval, real.bind(this));
@@ -1334,7 +1334,7 @@ function tenneyHeight(
 ): SonicWeaveValue {
   requireParameters({interval});
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    return pubTenney.bind(this)(interval);
+    return pubTenney.bind(this.rootContext)(interval);
   }
   return unaryBroadcast.bind(this)(interval, tenneyHeight.bind(this));
 }
@@ -1348,7 +1348,7 @@ function wilsonHeight(
 ): SonicWeaveValue {
   requireParameters({interval});
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    return pubWilson.bind(this)(interval);
+    return pubWilson.bind(this.rootContext)(interval);
   }
   return unaryBroadcast.bind(this)(interval, wilsonHeight.bind(this));
 }
@@ -1411,7 +1411,7 @@ function builtinCompare(
   if (isArrayOrRecord(x) || isArrayOrRecord(y)) {
     return binaryBroadcast.bind(this)(x, y, builtinCompare.bind(this));
   }
-  const c = compare.bind(this)(upcastBool(x), upcastBool(y));
+  const c = compare.bind(this.rootContext)(upcastBool(x), upcastBool(y));
   if (c < 0) {
     return fromInteger(-1);
   } else if (c > 0) {
@@ -1585,7 +1585,7 @@ det.__node__ = builtinNode(det);
 function hasConstantStructure_(this: ExpressionVisitor, scale?: Interval[]) {
   scale ??= this.currentScale;
   this.spendGas(scale.length * scale.length);
-  const rel = pubRelative.bind(this);
+  const rel = pubRelative.bind(this.rootContext);
   const monzos = scale.map(i => rel(i).value);
   for (const monzo of monzos) {
     if (monzo instanceof TimeReal) {
@@ -1611,7 +1611,7 @@ hasConstantStructure_.__node__ = builtinNode(
 
 function stepString_(this: ExpressionVisitor, scale?: Interval[]) {
   scale ??= this.currentScale;
-  const rel = pubRelative.bind(this);
+  const rel = pubRelative.bind(this.rootContext);
   const monzos = scale.map(i => rel(i).value);
   this.spendGas(monzos.length ** 2);
   return stepString(monzos);
@@ -1699,7 +1699,7 @@ function floor(
   interval: SonicWeaveValue
 ): SonicWeaveValue {
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    interval = pubRelative.bind(this)(upcastBool(interval));
+    interval = pubRelative.bind(this.rootContext)(upcastBool(interval));
     const n = Math.floor(interval.value.valueOf());
     return Interval.fromInteger(n, interval);
   }
@@ -1713,7 +1713,7 @@ function round(
   interval: SonicWeaveValue
 ): SonicWeaveValue {
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    interval = pubRelative.bind(this)(upcastBool(interval));
+    interval = pubRelative.bind(this.rootContext)(upcastBool(interval));
     const n = Math.round(interval.value.valueOf());
     return Interval.fromInteger(n, interval);
   }
@@ -1727,7 +1727,7 @@ function trunc(
   interval: SonicWeaveValue
 ): SonicWeaveValue {
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    interval = pubRelative.bind(this)(upcastBool(interval));
+    interval = pubRelative.bind(this.rootContext)(upcastBool(interval));
     const n = Math.trunc(interval.value.valueOf());
     return Interval.fromInteger(n, interval);
   }
@@ -1741,7 +1741,7 @@ function ceil(
   interval: SonicWeaveValue
 ): SonicWeaveValue {
   if (typeof interval === 'boolean' || interval instanceof Interval) {
-    interval = pubRelative.bind(this)(upcastBool(interval));
+    interval = pubRelative.bind(this.rootContext)(upcastBool(interval));
     const n = Math.ceil(interval.value.valueOf());
     return Interval.fromInteger(n, interval);
   }
@@ -1760,7 +1760,7 @@ function minimum(
   this: ExpressionVisitor,
   ...args: SonicWeavePrimitive[]
 ): SonicWeavePrimitive {
-  const c = compare.bind(this);
+  const c = compare.bind(this.rootContext);
   return args.slice(1).reduce((a, b) => (c(a, b) <= 0 ? a : b), args[0]);
 }
 minimum.__doc__ = 'Obtain the argument with the minimum value.';
@@ -1776,7 +1776,7 @@ function maximum(
   this: ExpressionVisitor,
   ...args: SonicWeavePrimitive[]
 ): SonicWeavePrimitive {
-  const c = compare.bind(this);
+  const c = compare.bind(this.rootContext);
   return args.slice(1).reduce((a, b) => (c(a, b) >= 0 ? a : b), args[0]);
 }
 maximum.__doc__ = 'Obtain the argument with the maximum value.';
@@ -2059,7 +2059,7 @@ function insert(
 ) {
   requireParameters({interval});
   scale ??= this.currentScale;
-  const cmp = compare.bind(this);
+  const cmp = compare.bind(this.rootContext);
   for (let i = 0; i < scale.length; ++i) {
     if (cmp(interval, scale[i]) < 0) {
       scale.splice(i, 0, interval);
@@ -2326,14 +2326,14 @@ templateArg.__doc__ =
 templateArg.__node__ = builtinNode(templateArg);
 
 function repr(this: ExpressionVisitor, value: SonicWeaveValue) {
-  return pubRepr.bind(this)(value);
+  return pubRepr.bind(this.rootContext)(value);
 }
 repr.__doc__ =
   'Obtain a string representation of the value (with color and label).';
 repr.__node__ = builtinNode(repr);
 
 function str(this: ExpressionVisitor, value: SonicWeaveValue) {
-  return pubStr.bind(this)(value);
+  return pubStr.bind(this.rootContext)(value);
 }
 str.__doc__ =
   'Obtain a string representation of the value (w/o color or label).';
@@ -2346,7 +2346,7 @@ function vstr(
   if (isArrayOrRecord(value)) {
     return unaryBroadcast.bind(this)(value, vstr.bind(this));
   }
-  return pubStr.bind(this)(value);
+  return pubStr.bind(this.rootContext)(value);
 }
 vstr.__doc__ =
   'Obtain a string representation of a primitive value (w/o color or label). Vectorizes over arrays.';
@@ -2359,10 +2359,10 @@ function lstr(
 ): SonicWeaveValue {
   const m = upcastBool(maxLength).toInteger();
   if (isArrayOrRecord(value)) {
-    const l = pubLstr.bind(this);
+    const l = pubLstr.bind(this.rootContext);
     return unaryBroadcast.bind(this)(value, v => l(v, m));
   }
-  return pubLstr.bind(this)(value, m);
+  return pubLstr.bind(this.rootContext)(value, m);
 }
 lstr.__doc__ =
   'Obtain a "best effort" short string representing a primitive value. Vectorizes over arrays.';
@@ -2473,7 +2473,7 @@ function centsColor(
     this.spendGas(interval.length);
     return interval.map(centsColor as any);
   }
-  return pubCentsColor.bind(this)(upcastBool(interval));
+  return pubCentsColor.bind(this.rootContext)(upcastBool(interval));
 }
 centsColor.__doc__ =
   'Color based on the size of the interval. Hue wraps around every 1200 cents.';
@@ -2487,7 +2487,7 @@ export function factorColor(
     this.spendGas(interval.length);
     return interval.map(factorColor as any);
   }
-  return pubFactorColor.bind(this)(upcastBool(interval));
+  return pubFactorColor.bind(this.rootContext)(upcastBool(interval));
 }
 factorColor.__doc__ = 'Color an interval based on its prime factors.';
 factorColor.__node__ = builtinNode(factorColor);

--- a/src/stdlib/builtin/temper.ts
+++ b/src/stdlib/builtin/temper.ts
@@ -328,7 +328,7 @@ function PrimeMapping(
   this: ExpressionVisitor,
   ...newPrimes: (Interval | undefined)[]
 ) {
-  const rel = pubRelative.bind(this);
+  const rel = pubRelative.bind(this.rootContext);
   const np = newPrimes.map((p, i) =>
     p ? rel(p).value : TimeMonzo.fromBigInt(BIG_INT_PRIMES[i])
   );
@@ -342,7 +342,7 @@ function PrimeMapping(
       return unaryBroadcast.bind(this)(interval, m);
     }
     interval = upcastBool(interval);
-    const monzo = pubRelative.bind(this)(interval).value;
+    const monzo = pubRelative.bind(this.rootContext)(interval).value;
     if (monzo instanceof TimeReal) {
       return new Interval(
         monzo,
@@ -368,7 +368,7 @@ function PrimeMapping(
     }
     return new Interval(mapped, 'logarithmic', 0, node, interval);
   }
-  const r = repr.bind(this);
+  const r = repr.bind(this.rootContext);
   Object.defineProperty(mapper, 'name', {
     value: `PrimeMapping(${newPrimes.map(r).join(', ')})`,
     enumerable: false,


### PR DESCRIPTION
Only require a root context if a full expression visitor is not needed.