### PR TITLE
Limit TypeScript ESLint rules to no-this-alias/no-unused-vars

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,23 +60,23 @@ export default [
       },
     },
     rules: {
-      'no-empty': 0,
-      'no-constant-condition': 0,
-      'prefer-const': ['error', {destructuring: 'all'}],
-      'no-restricted-syntax': ['error', 'SequenceExpression'],
-      '@typescript-eslint/no-explicit-any': 0,
-      '@typescript-eslint/ban-ts-comment': 0,
       '@typescript-eslint/no-this-alias': [
         'error',
         {
-          allowedNames: ['self'],
+          allowedNames: ['self', 'scopeParent'],
         },
       ],
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
-          varsIgnorePattern: '_',
-        },
+          'args': 'all',
+          'argsIgnorePattern': '^_',
+          'caughtErrors': 'all',
+          'caughtErrorsIgnorePattern': '^_',
+          'destructuredArrayIgnorePattern': '^_',
+          'varsIgnorePattern': '^_',
+          'ignoreRestSiblings': true
+        }
       ],
     },
   },

--- a/src/__benchmarks__/prelude.bench.ts
+++ b/src/__benchmarks__/prelude.bench.ts
@@ -65,10 +65,9 @@ describe('Prelude AST visiting', () => {
 });
 
 describe('Prelude riffs', () => {
-  /* eslint-disable @typescript-eslint/no-unused-expressions */
   bench('Euler genus (stdlib)', () => {
     for (let n = 5; n < 100; ++n) {
-      sw`eulerGenus(${n})`;
+      void sw`eulerGenus(${n})`;
     }
   });
 

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -115,7 +115,7 @@ describe('CLI REPL error handling', () => {
     let options: ReplOptions | undefined;
     repl(opts => {
       options = opts as ReplOptions;
-      return {} as any;
+      return {} as unknown;
     });
 
     const evaluate = options?.eval;
@@ -124,14 +124,20 @@ describe('CLI REPL error handling', () => {
     const fakeRepl = {
       setPrompt() {},
       displayPrompt() {},
-    } as any;
+    } as unknown;
 
     let err: Error | null = null;
     let value: unknown;
-    evaluate!.call(fakeRepl, 'print(str(4/3))\n', {} as any, 'repl', (e, v) => {
-      err = e;
-      value = v;
-    });
+    evaluate!.call(
+      fakeRepl,
+      'print(str(4/3))\n',
+      {} as unknown,
+      'repl',
+      (e, v) => {
+        err = e;
+        value = v;
+      },
+    );
 
     expect(err).toBeNull();
     expect(value).toBeUndefined();
@@ -141,7 +147,7 @@ describe('CLI REPL error handling', () => {
     let options: ReplOptions | undefined;
     repl(opts => {
       options = opts as ReplOptions;
-      return {} as any;
+      return {} as unknown;
     });
 
     const evaluate = options?.eval;
@@ -150,13 +156,13 @@ describe('CLI REPL error handling', () => {
     const fakeRepl = {
       setPrompt() {},
       displayPrompt() {},
-    } as any;
+    } as unknown;
 
     let firstErr: Error | null = null;
     evaluate!.call(
       fakeRepl,
       'print("unterminated)\n',
-      {} as any,
+      {} as unknown,
       'repl',
       (err: Error | null) => {
         firstErr = err;
@@ -166,7 +172,7 @@ describe('CLI REPL error handling', () => {
 
     let secondErr: Error | null = null;
     let secondValue: unknown;
-    evaluate!.call(fakeRepl, '1\n', {} as any, 'repl', (err, value) => {
+    evaluate!.call(fakeRepl, '1\n', {} as unknown, 'repl', (err, value) => {
       secondErr = err;
       secondValue = value;
     });

--- a/src/__tests__/fjs.spec.ts
+++ b/src/__tests__/fjs.spec.ts
@@ -234,7 +234,7 @@ describe('FJS interval inflector', () => {
       const imperfect = ![1, 4, 5].includes(degree);
       const node: Pythagorean = {
         type: 'Pythagorean',
-        quality: {fraction: vulgar, quality: quality as any},
+        quality: {fraction: vulgar, quality: quality as unknown},
         augmentations,
         degree: {base, octaves, negative: false, imperfect},
       };

--- a/src/__tests__/interval.spec.ts
+++ b/src/__tests__/interval.spec.ts
@@ -50,6 +50,19 @@ describe('Idempotent formatting', () => {
     expect(node.numerator).toBe(4);
     expect(node.denominator).toBe(12);
   });
+
+  it('has stable signed equal temperament against existing node', () => {
+    const negativeMajorThird = TimeMonzo.fromEqualTemperament('-4/12');
+    const node = intervalValueAs(negativeMajorThird, {
+      type: 'NedjiLiteral',
+      numerator: 4,
+      denominator: 12,
+      equaveNumerator: null,
+      equaveDenominator: null,
+    }) as NedjiLiteral;
+    expect(node.numerator).toBe(-4);
+    expect(node.denominator).toBe(12);
+  });
 });
 
 describe('Interchange format', () => {
@@ -147,7 +160,7 @@ const SERIALIZED =
 
 describe('Interval JSON serialization', () => {
   it('can be serialized alongside other data', () => {
-    const data: any = [
+    const data: unknown = [
       'hello',
       sw`12`,
       12,

--- a/src/__tests__/monzo.spec.ts
+++ b/src/__tests__/monzo.spec.ts
@@ -489,7 +489,7 @@ describe('JSON serialization', () => {
   it('can deserialize an array of primitives, fractions and monzos', () => {
     const serialized =
       '["Hello, world!",{"n":10,"d":7},{"type":"TimeReal","t":-1,"v":777},3.5,{"type":"TimeMonzo","t":{"n":0,"d":1},"p":[-4,1,4,1,-1,1,0,1,0,1,0,1,0,1,0,1,0,1],"r":{"n":1,"d":1}},null,{"type":"TimeReal","t":0,"v":"nan"},{"type":"TimeReal","t":1,"v":"inf"}]';
-    function reviver(key: string, value: any) {
+    function reviver(key: string, value: unknown) {
       return TimeMonzo.reviver(
         key,
         TimeReal.reviver(key, Fraction.reviver(key, value)),

--- a/src/__tests__/pythagorean.spec.ts
+++ b/src/__tests__/pythagorean.spec.ts
@@ -130,7 +130,7 @@ describe('Pythagorean interval construction from parts', () => {
     const imperfect = ![1, 4, 5, 1.5, 4.5, 7.5].includes(base);
     const node: Pythagorean = {
       type: 'Pythagorean',
-      quality: {fraction, quality: quality as any},
+      quality: {fraction, quality: quality as unknown},
       augmentations,
       degree: {negative: degree < 0, base, octaves, imperfect},
     };

--- a/src/__tests__/scale-workshop-2.spec.ts
+++ b/src/__tests__/scale-workshop-2.spec.ts
@@ -177,7 +177,7 @@ describe('Line parser', () => {
     ).toBeTruthy();
   });
 
-  it('parses composites (any)', () => {
+  it('parses composites (unknown)', () => {
     const result = parseLine('3\\15 + 103/101 + 6.9');
     const vector = Array(DEFAULT_NUMBER_OF_COMPONENTS).fill(new Fraction(0));
     vector[0] = new Fraction(3, 15).add('69/12000');

--- a/src/__tests__/words.spec.ts
+++ b/src/__tests__/words.spec.ts
@@ -183,7 +183,7 @@ describe('getStepVector()', () => {
   it('returns zero vector if empty word is passed', () => {
     expect(getStepVector('', 1000)).toStrictEqual(zeroVector());
   });
-  it('creates a step vector from any 0-based substring of a string', () => {
+  it('creates a step vector from unknown 0-based substring of a string', () => {
     const lydian = 'LLLsLLs';
     const zeroStep = getStepVector(lydian, 0);
     expect(zeroStep).toStrictEqual(zeroVector());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {relative, repr} from './stdlib/index.js';
 import {Interval} from './interval.js';
 import {
-  ExpressionVisitor,
   StatementVisitor,
   evaluateSource,
   getSourceVisitor,
@@ -12,7 +10,6 @@ import type {REPLServer, ReplOptions} from 'repl';
 import type {Context} from 'node:vm';
 import * as parenCounterParser from './parser/paren-counter.js';
 import {literalToString} from './expression.js';
-import {TimeReal} from './monzo.js';
 import packageJson from '../package.json' with {type: 'json'};
 const parenCounter = (
   parenCounterParser as {
@@ -154,19 +151,20 @@ export function repl(start: (options?: string | ReplOptions) => REPLServer) {
   const visitor = new StatementVisitor(globalVisitor);
 
   let currentCmd = '';
+  type ParenCounts = {parens: number; squares: number; curlies: number};
 
   function evaluateStatement(
     this: REPLServer,
     evalCmd: string,
-    context: Context,
-    file: string,
-    cb: (err: Error | null, result: any) => void,
+    _context: Context,
+    _file: string,
+    cb: (err: Error | null, result: unknown) => void,
   ) {
     currentCmd += evalCmd;
 
-    let counts: any;
+    let counts: ParenCounts;
     try {
-      counts = parenCounter(currentCmd);
+      counts = parenCounter(currentCmd) as ParenCounts;
     } catch (e) {
       currentCmd = '';
       if (e instanceof Error) {
@@ -176,7 +174,7 @@ export function repl(start: (options?: string | ReplOptions) => REPLServer) {
           cb(e, undefined);
         }
       } else {
-        cb(new Error(repr.bind(visitor.rootContext)(e as any)), undefined);
+        cb(new Error(repr.bind(visitor.rootContext)(e as never)), undefined);
       }
       return;
     }
@@ -230,14 +228,11 @@ export function repl(start: (options?: string | ReplOptions) => REPLServer) {
       }
     } catch (e) {
       currentCmd = '';
-      if (typeof e === 'string') {
-        // eslint-disable-next-line no-ex-assign
-        e = new Error(e);
-      }
+      const thrown = typeof e === 'string' ? new Error(e) : e;
       let err =
-        e instanceof Error
-          ? e
-          : new Error(repr.bind(visitor.rootContext)(e as any));
+        thrown instanceof Error
+          ? thrown
+          : new Error(repr.bind(visitor.rootContext)(thrown as never));
       if (err.name === 'SyntaxError') {
         err = new Error(err.message);
       }

--- a/src/context.ts
+++ b/src/context.ts
@@ -85,26 +85,42 @@ export class RootContext {
    * const data = JSON.parse(serializedData, RootContext.reviver);
    * ```
    *
-   * @param key Property name.
+   * @param _key Property name.
    * @param value Property value.
    * @returns Deserialized {@link RootContext} instance or other data without modifications.
    */
-  static reviver(key: string, value: any) {
+  static reviver(_key: string, value: unknown) {
+    type SerializedRootContext = {
+      type: 'RootContext';
+      gas: number;
+      title: string;
+      unisonFrequency?: unknown;
+      C4: unknown;
+      up: unknown;
+      lift: unknown;
+      trackingIndex: number;
+      mosConfig: unknown;
+    };
     if (
       typeof value === 'object' &&
       value !== null &&
+      'type' in value &&
       value.type === 'RootContext'
     ) {
-      const result = new RootContext(value.gas);
-      result.title = value.title;
+      const serialized = value as SerializedRootContext;
+      const result = new RootContext(serialized.gas);
+      result.title = serialized.title;
       result.unisonFrequency =
-        TimeMonzo.reviver('unisonFrequency', value.unisonFrequency) ??
-        undefined;
-      result.C4 = TimeMonzo.reviver('C4', value.C4);
-      result.up = Interval.reviver('up', value.up);
-      result.lift = Interval.reviver('lift', value.lift);
-      result.trackingIndex = value.trackingIndex;
-      result.mosConfig = reviveMosConfig(value.mosConfig);
+        (TimeMonzo.reviver('unisonFrequency', serialized.unisonFrequency) as
+          | TimeMonzo
+          | undefined) ?? undefined;
+      result.C4 = TimeMonzo.reviver('C4', serialized.C4) as TimeMonzo;
+      result.up = Interval.reviver('up', serialized.up) as Interval;
+      result.lift = Interval.reviver('lift', serialized.lift) as Interval;
+      result.trackingIndex = serialized.trackingIndex;
+      result.mosConfig = reviveMosConfig(
+        serialized.mosConfig as Parameters<typeof reviveMosConfig>[0],
+      );
       return result;
     }
     return value;

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import {ABSURD_EXPONENT, validateBigInt} from './utils.js';
 import {BinaryPrefix, MetricPrefix} from './tools.js';
 import {Pythagorean, AbsolutePitch} from './pythagorean.js';
@@ -850,27 +848,27 @@ export function powNodes(
 // == Placeholders for future implementation ==
 
 /** @hidden */
-export function ipowNodes(a?: IntervalLiteral, b?: IntervalLiteral) {
+export function ipowNodes(_a?: IntervalLiteral, _b?: IntervalLiteral) {
   return undefined;
 }
 
 /** @hidden */
-export function logNodes(a?: IntervalLiteral, b?: IntervalLiteral) {
+export function logNodes(_a?: IntervalLiteral, _b?: IntervalLiteral) {
   return undefined;
 }
 
 /** @hidden */
-export function lensAddNodes(a?: IntervalLiteral, b?: IntervalLiteral) {
+export function lensAddNodes(_a?: IntervalLiteral, _b?: IntervalLiteral) {
   return undefined;
 }
 
 /** @hidden */
-export function lensSubNodes(a?: IntervalLiteral, b?: IntervalLiteral) {
+export function lensSubNodes(_a?: IntervalLiteral, _b?: IntervalLiteral) {
   return undefined;
 }
 
 /** @hidden */
-export function pitchRoundToNodes(a?: IntervalLiteral, b?: IntervalLiteral) {
+export function pitchRoundToNodes(_a?: IntervalLiteral, _b?: IntervalLiteral) {
   return undefined;
 }
 
@@ -1122,11 +1120,11 @@ export function numberToDecimalLiteral(
   num: number | Fraction,
   flavor: NumericFlavor,
 ): DecimalLiteral {
-  let [wholeStr, fractional] = num.toString().split('.');
+  const [wholeStr, fractionalPart] = num.toString().split('.');
   let sign: Sign = '';
   let whole = BigInt(wholeStr);
   let exponent: number | null = null;
-  fractional ??= '';
+  let fractional = fractionalPart ?? '';
   if (whole < 0n) {
     sign = '-';
     whole = -whole;
@@ -1169,7 +1167,7 @@ export function integerToVectorComponent(num: number): VectorComponent {
 
 export function literalToJSON(
   literal?: IntervalLiteral | CoIntervalLiteral | ValBasisLiteral,
-): any {
+): unknown {
   if (!literal) {
     return undefined;
   }
@@ -1239,53 +1237,65 @@ export function literalToJSON(
 }
 
 export function intervalLiteralFromJSON(
-  object: any,
+  object: unknown,
 ): IntervalLiteral | undefined {
   if (object === undefined) {
     return undefined;
   }
-  const type: IntervalLiteral['type'] | 'i' | 'f' | 'c' | 'n' = object.type;
+  if (typeof object !== 'object' || object === null || !('type' in object)) {
+    return undefined;
+  }
+  const serialized = object as Record<string, unknown>;
+  const type = serialized.type as
+    | IntervalLiteral['type']
+    | 'i'
+    | 'f'
+    | 'c'
+    | 'n';
   switch (type) {
     // Decompress most common types
     case 'i':
-      return {type: 'IntegerLiteral', value: BigInt(object.v)};
+      return {type: 'IntegerLiteral', value: BigInt(serialized.v as string)};
     case 'f':
       return {
         type: 'FractionLiteral',
-        numerator: BigInt(object.n),
-        denominator: BigInt(object.d),
+        numerator: BigInt(serialized.n as string),
+        denominator: BigInt(serialized.d as string),
       };
     case 'c':
       return {
         type: 'CentsLiteral',
-        sign: object.s,
-        whole: BigInt(object.w),
-        fractional: object.f,
-        exponent: object.e,
-        real: object.r,
+        sign: serialized.s as Sign,
+        whole: BigInt(serialized.w as string),
+        fractional: serialized.f as string,
+        exponent: serialized.e as number | null,
+        real: serialized.r as boolean,
       };
     case 'n':
       return {
         type: 'NedjiLiteral',
-        numerator: object.n,
-        denominator: object.d,
-        equaveNumerator: object.p,
-        equaveDenominator: object.q,
+        numerator: serialized.n as number,
+        denominator: serialized.d as number,
+        equaveNumerator: serialized.p as number | null,
+        equaveDenominator: serialized.q as number | null,
       };
     // Revive BigInts
     case 'DecimalLiteral':
-      return {...object, whole: BigInt(object.whole)};
+      return {
+        ...(serialized as unknown as DecimalLiteral),
+        whole: BigInt(serialized.whole as string),
+      };
     case 'RadicalLiteral':
       return {
         type,
-        argument: Fraction.reviver('argument', object.argument) as Fraction,
-        exponent: Fraction.reviver('exponent', object.exponent) as Fraction,
+        argument: Fraction.reviver('argument', serialized.argument) as Fraction,
+        exponent: Fraction.reviver('exponent', serialized.exponent) as Fraction,
       };
     case 'SquareSuperparticular':
       return {
         type,
-        start: BigInt(object.start),
-        end: object.end && BigInt(object.end),
+        start: BigInt(serialized.start as string),
+        end: serialized.end ? BigInt(serialized.end as string) : null,
       };
     case 'StepLiteral':
     case 'CentLiteral':
@@ -1299,7 +1309,7 @@ export function intervalLiteralFromJSON(
     case 'HertzLiteral':
     case 'SecondLiteral':
     case 'MonzoLiteral':
-      return object;
+      return serialized as unknown as IntervalLiteral;
     case 'IntegerLiteral':
     case 'FractionLiteral':
     case 'NedjiLiteral':

--- a/src/fjs.ts
+++ b/src/fjs.ts
@@ -35,7 +35,7 @@ const NEUTRAL_BRIDGING_RADIUS = 92.1;
 const SEMIQUARTAL_BRIDGING_RADIUS = 137.2;
 
 // XXX: Not much thought was given to this choice.
-const TONE_SPLITTER_BRIDGING_RADIUS = SEMIAPOTOME;
+const TONE_SPLITTER_BRIDGING_RADIUS = SEMIQUARTAL_BRIDGING_RADIUS;
 
 const FIFTH = PRIME_CENTS[1] - PRIME_CENTS[0];
 
@@ -66,8 +66,7 @@ function masterAlgorithm(
 }
 
 // The original NFJS master algorithm by M-yac
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function myacNeutralMaster(primeCents: number) {
+function _myacNeutralMaster(primeCents: number) {
   let pythagoras = 0;
   if (circleDistance(primeCents, pythagoras) < NFJS_RADIUS) {
     return 0;
@@ -137,10 +136,14 @@ function toneSplitterMaster(primeCents: number): [number, number] {
   let k = 0.5;
 
   while (true) {
-    if (circleDistance(primeCents, pythagoras) < SEMIQUARTAL_BRIDGING_RADIUS) {
+    if (
+      circleDistance(primeCents, pythagoras) < TONE_SPLITTER_BRIDGING_RADIUS
+    ) {
       return [k, 0.5 - k];
     }
-    if (circleDistance(primeCents, -pythagoras) < SEMIQUARTAL_BRIDGING_RADIUS) {
+    if (
+      circleDistance(primeCents, -pythagoras) < TONE_SPLITTER_BRIDGING_RADIUS
+    ) {
       return [-k, k - 0.5];
     }
     pythagoras += FIFTH;
@@ -151,7 +154,8 @@ function toneSplitterMaster(primeCents: number): [number, number] {
 function* commaGenerator(master: typeof masterAlgorithm): Generator<TimeMonzo> {
   let i = 2;
   while (i < PRIME_CENTS.length) {
-    let [twos, threes] = master(PRIME_CENTS[i]);
+    const [initialTwos, threes] = master(PRIME_CENTS[i]);
+    let twos = initialTwos;
     let commaCents =
       PRIME_CENTS[i] + twos * PRIME_CENTS[0] + threes * PRIME_CENTS[1];
     while (commaCents > 600) {

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -298,25 +298,37 @@ export class Interval {
    * const data = JSON.parse(serializedData, Interval.reviver);
    * ```
    *
-   * @param key Property name.
+   * @param _key Property name.
    * @param value Property value.
    * @returns Deserialized {@link Interval} instance or other data without modifications.
    */
-  static reviver(key: string, value: any) {
+  static reviver(_key: string, value: unknown) {
+    type SerializedInterval = {
+      type: 'Interval';
+      v: unknown;
+      d: number;
+      s: number;
+      n: unknown;
+      l: string;
+      c: string | null;
+      t: number[];
+    };
     if (
       typeof value === 'object' &&
       value !== null &&
+      'type' in value &&
       value.type === 'Interval'
     ) {
+      const serialized = value as SerializedInterval;
       const result = new Interval(
-        reviveMonzo(value.v),
-        value.d ? 'logarithmic' : 'linear',
-        value.s,
-        intervalLiteralFromJSON(value.n),
+        reviveMonzo(serialized.v as Parameters<typeof reviveMonzo>[0]),
+        serialized.d ? 'logarithmic' : 'linear',
+        serialized.s,
+        intervalLiteralFromJSON(serialized.n),
       );
-      result.label = value.l;
-      result.color = value.c && new Color(value.c);
-      result.trackingIds = new Set(value.t);
+      result.label = serialized.l;
+      result.color = serialized.c ? new Color(serialized.c) : undefined;
+      result.trackingIds = new Set(serialized.t);
       return result;
     }
     return value;
@@ -326,7 +338,7 @@ export class Interval {
    * Serialize the time monzo to a JSON compatible object.
    * @returns The serialized object with property `type` set to `'Interval'`.
    */
-  toJSON(): any {
+  toJSON(): unknown {
     return {
       type: 'Interval',
       v: this.value.toJSON(),
@@ -1944,7 +1956,7 @@ export class ValBasis {
     }
     const node = {
       type: 'ValBasisLiteral',
-      basis: [] as any[],
+      basis: [] as unknown[],
     };
     const bail = () => `basis(${this.value.map(m => m.toString()).join(', ')})`;
     for (let monzo of this.value) {

--- a/src/monzo.ts
+++ b/src/monzo.ts
@@ -226,17 +226,20 @@ export class TimeReal {
    * const data = JSON.parse(serializedData, TimeReal.reviver);
    * ```
    *
-   * @param key Property name.
+   * @param _key Property name.
    * @param value Property value.
    * @returns Deserialized {@link TimeReal} instance or other data without modifications.
    */
-  static reviver(key: string, value: any) {
+  static reviver(_key: string, value: unknown) {
+    type SerializedTimeReal = {type: 'TimeReal'; t: number; v: number | string};
     if (
       typeof value === 'object' &&
       value !== null &&
+      'type' in value &&
       value.type === 'TimeReal'
     ) {
-      let v: number | string = value.v;
+      const serialized = value as SerializedTimeReal;
+      let v: number | string = serialized.v;
       if (v === 'nan') {
         v = NaN;
       } else if (v === 'inf') {
@@ -244,7 +247,7 @@ export class TimeReal {
       } else if (v === '-inf') {
         v = -Infinity;
       }
-      return new TimeReal(value.t, v as number);
+      return new TimeReal(serialized.t, v as number);
     }
     return value;
   }
@@ -1128,8 +1131,7 @@ export class TimeMonzo {
     }
     if (!residual.n) {
       timeExponent = new Fraction(0);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      primeExponents = primeExponents.map(_ => new Fraction(0));
+      primeExponents = primeExponents.map(() => new Fraction(0));
     }
     this.timeExponent = timeExponent;
     this.primeExponents = primeExponents;
@@ -1304,22 +1306,30 @@ export class TimeMonzo {
    * const data = JSON.parse(serializedData, TimeMonzo.reviver);
    * ```
    *
-   * @param key Property name.
+   * @param _key Property name.
    * @param value Property value.
    * @returns Deserialized {@link TimeMonzo} instance or other data without modifications.
    */
-  static reviver(key: string, value: any) {
+  static reviver(_key: string, value: unknown) {
+    type SerializedTimeMonzo = {
+      type: 'TimeMonzo';
+      t: unknown;
+      p: number[];
+      r: unknown;
+    };
     if (
       typeof value === 'object' &&
       value !== null &&
+      'type' in value &&
       value.type === 'TimeMonzo'
     ) {
-      const timeExponent = Fraction.reviver('t', value.t) as Fraction;
+      const serialized = value as SerializedTimeMonzo;
+      const timeExponent = Fraction.reviver('t', serialized.t) as Fraction;
       const primeExponents: Fraction[] = [];
-      for (let i = 0; i < value.p.length; i += 2) {
-        primeExponents.push(new Fraction(value.p[i], value.p[i + 1]));
+      for (let i = 0; i < serialized.p.length; i += 2) {
+        primeExponents.push(new Fraction(serialized.p[i], serialized.p[i + 1]));
       }
-      const residual = Fraction.reviver('r', value.r) as Fraction;
+      const residual = Fraction.reviver('r', serialized.r) as Fraction;
       return new TimeMonzo(timeExponent, primeExponents, residual);
     }
     return value;
@@ -2658,7 +2668,10 @@ export class TimeMonzo {
     if (this.timeExponent.n) {
       throw new Error('Time exponent prevents factorization over integers.');
     }
-    const result: Map<number, Fraction> = primeFactorize(this.residual) as any;
+    const result = primeFactorize(this.residual) as unknown as Map<
+      number,
+      Fraction
+    >;
     for (const [key, value] of result) {
       result.set(key, new Fraction(value));
     }
@@ -2789,13 +2802,13 @@ export class TimeMonzo {
     if (this.isEqualTemperament()) {
       try {
         const {fractionOfEquave, equave} = this.toEqualTemperament();
-        let {s, n, d} = fractionOfEquave;
-        n *= s;
+        const {s, n, d} = fractionOfEquave;
+        const scaledNumerator = n * s;
         if (!node) {
           if (equave.equals(TWO)) {
             return {
               type: 'NedjiLiteral',
-              numerator: n,
+              numerator: scaledNumerator,
               denominator: d,
               equaveNumerator: null,
               equaveDenominator: null,
@@ -2803,7 +2816,7 @@ export class TimeMonzo {
           } else {
             return {
               type: 'NedjiLiteral',
-              numerator: n,
+              numerator: scaledNumerator,
               denominator: d,
               equaveNumerator: equave.s * equave.n,
               equaveDenominator: equave.d,
@@ -2824,12 +2837,12 @@ export class TimeMonzo {
         if (denominator === node.denominator) {
           return {
             ...node,
-            numerator: (denominator / d) * n,
+            numerator: (denominator / d) * scaledNumerator,
           };
         }
         return {
           ...node,
-          numerator: n,
+          numerator: scaledNumerator,
           denominator: d,
         };
       } catch {
@@ -3069,9 +3082,9 @@ export function reviveMonzo(
   data: ReturnType<TimeReal['toJSON']> | ReturnType<TimeMonzo['toJSON']>,
 ): TimeReal | TimeMonzo {
   if (data.type === 'TimeReal') {
-    return TimeReal.reviver('value', data);
+    return TimeReal.reviver('value', data) as TimeReal;
   } else if (data.type === 'TimeMonzo') {
-    return TimeMonzo.reviver('value', data);
+    return TimeMonzo.reviver('value', data) as TimeMonzo;
   }
   throw new Error(`Unrecognized monzo type '${data.type}'`);
 }

--- a/src/parser/__tests__/expression.spec.ts
+++ b/src/parser/__tests__/expression.spec.ts
@@ -2225,7 +2225,7 @@ describe('SonicWeave expression evaluator', () => {
   });
 
   it('ignores ternary broadcasting of records', () => {
-    const oof = evaluate('1 where [true, false] else #{a: 2}') as any;
+    const oof = evaluate('1 where [true, false] else #{a: 2}') as unknown;
     expect(oof).toHaveLength(2);
     expect(oof[0].valueOf()).toBe(1);
     expect(oof[1].a.valueOf()).toBe(2);

--- a/src/parser/__tests__/modules.spec.ts
+++ b/src/parser/__tests__/modules.spec.ts
@@ -1,12 +1,5 @@
 import {describe, it, expect} from 'vitest';
 import {evaluateSource} from '../../parser/index.js';
-import {Interval} from '../../interval.js';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function parseSource(source: string) {
-  const visitor = evaluateSource(source, false);
-  return visitor.mutables.get('$') as Interval[];
-}
 
 function expand(source: string) {
   const visitor = evaluateSource(source, false);

--- a/src/parser/__tests__/sonic-weave-ast.spec.ts
+++ b/src/parser/__tests__/sonic-weave-ast.spec.ts
@@ -2,13 +2,14 @@ import {describe, it, expect} from 'vitest';
 
 import * as sonicWeaveAstParser from '../sonic-weave-ast.js';
 
-const parse = (sonicWeaveAstParser as {parse: (source: string) => any}).parse;
-
 // Debug
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function d(thing: any) {
+function d(thing: unknown) {
   console.dir(thing, {depth: null});
 }
+
+const parse = (sonicWeaveAstParser as {parse: (source: string) => unknown})
+  .parse;
 
 function parseSingle(source: string) {
   return parse(source).body[0];

--- a/src/parser/__tests__/tag.spec.ts
+++ b/src/parser/__tests__/tag.spec.ts
@@ -95,6 +95,17 @@ describe('SonicWeave template tag', () => {
     expect(first).toBe('first');
   });
 
+  it('preserves conforming function template arguments', () => {
+    const fn = (() => true) as (() => boolean) & {
+      __doc__: string;
+      __node__: unknown;
+    };
+    fn.__doc__ = '';
+    fn.__node__ = null;
+    const value = sw`${fn};templateArg(0)`;
+    expect(value).toBe(fn);
+  });
+
   it('rejects defer at root scope', () => {
     expect(() => sw`defer 2;3`).toThrow(
       'Deferred actions not allowed when evaluating tagged templates.',

--- a/src/parser/__tests__/vector-broadcasting.spec.ts
+++ b/src/parser/__tests__/vector-broadcasting.spec.ts
@@ -3,7 +3,7 @@ import {evaluateExpression, sw} from '../parser.js';
 import {Interval} from '../../interval.js';
 import {SonicWeavePrimitive} from '../../stdlib/index.js';
 
-function sw0D(strings: TemplateStringsArray, ...args: any[]): number {
+function sw0D(strings: TemplateStringsArray, ...args: unknown[]): number {
   const result = sw(strings, ...args);
   if (result instanceof Interval) {
     return result.valueOf();
@@ -11,8 +11,8 @@ function sw0D(strings: TemplateStringsArray, ...args: any[]): number {
   throw new Error('Failed to evaluate to an interval.');
 }
 
-function sw1D(strings: TemplateStringsArray, ...args: any[]): number[] {
-  const result: any = sw(strings, ...args);
+function sw1D(strings: TemplateStringsArray, ...args: unknown[]): number[] {
+  const result: unknown = sw(strings, ...args);
   if (!Array.isArray(result)) {
     throw new Error('Failed to evaluate to an array.');
   }
@@ -26,8 +26,8 @@ function sw1D(strings: TemplateStringsArray, ...args: any[]): number[] {
   return result;
 }
 
-function sw2D(strings: TemplateStringsArray, ...args: any[]): number[][] {
-  const result: any = sw(strings, ...args);
+function sw2D(strings: TemplateStringsArray, ...args: unknown[]): number[][] {
+  const result: unknown = sw(strings, ...args);
   if (!Array.isArray(result)) {
     throw new Error('Failed to evaluate to an array.');
   }
@@ -48,13 +48,13 @@ function sw2D(strings: TemplateStringsArray, ...args: any[]): number[][] {
 
 function swRec(
   strings: TemplateStringsArray,
-  ...args: any[]
+  ...args: unknown[]
 ): Record<string, number> {
-  const result: any = sw(strings, ...args);
+  const result: unknown = sw(strings, ...args);
   return Object.fromEntries(
     Object.entries(result).map(([key, value]) => [
       key,
-      (value as any).valueOf(),
+      (value as unknown).valueOf(),
     ]),
   ) as Record<string, number>;
 }

--- a/src/parser/expression.ts
+++ b/src/parser/expression.ts
@@ -179,7 +179,6 @@ function includes(element: SonicWeaveValue, scale: SonicWeaveValue[]) {
   return scale.includes(element);
 }
 
-const TWO_MONZO = new TimeMonzo(ZERO, [ONE]);
 const TEN_MONZO = new TimeMonzo(ZERO, [ONE, ZERO, ONE]);
 const KIBI_MONZO = new TimeMonzo(ZERO, [F(10)]);
 const CENT_MONZO = new TimeMonzo(ZERO, [F(1, 1200)]);
@@ -663,9 +662,11 @@ export class ExpressionVisitor {
       return sonicTruth(test) ? consequent : alternate;
     }
     return where(
-      this.visit(node.test) as any,
-      this.visit(node.consequent) as any,
-      this.visit(node.alternate) as any,
+      this.visit(node.test) as SonicWeavePrimitive | SonicWeavePrimitive[],
+      this.visit(node.consequent) as
+        | SonicWeavePrimitive
+        | SonicWeavePrimitive[],
+      this.visit(node.alternate) as SonicWeavePrimitive | SonicWeavePrimitive[],
     );
   }
 
@@ -709,9 +710,9 @@ export class ExpressionVisitor {
       }
     }
     return rr(
-      this.visit(node.left) as any,
-      this.visit(node.middle) as any,
-      this.visit(node.right) as any,
+      this.visit(node.left) as SonicWeavePrimitive | SonicWeavePrimitive[],
+      this.visit(node.middle) as SonicWeavePrimitive | SonicWeavePrimitive[],
+      this.visit(node.right) as SonicWeavePrimitive | SonicWeavePrimitive[],
     );
   }
 
@@ -1823,15 +1824,30 @@ export class ExpressionVisitor {
         // eslint-disable-next-line eqeqeq
         return left != right;
       case '<=':
-        return (left as any) <= (right as any);
+        return (
+          (left as number | string | bigint) <=
+          (right as number | string | bigint)
+        );
       case '<':
-        return (left as any) < (right as any);
+        return (
+          (left as number | string | bigint) <
+          (right as number | string | bigint)
+        );
       case '>=':
-        return (left as any) >= (right as any);
+        return (
+          (left as number | string | bigint) >=
+          (right as number | string | bigint)
+        );
       case '>':
-        return (left as any) > (right as any);
+        return (
+          (left as number | string | bigint) >
+          (right as number | string | bigint)
+        );
       case 'al~':
-        return (left as any) ?? (right as any);
+        return (
+          (left as SonicWeaveValue | null | undefined) ??
+          (right as SonicWeaveValue)
+        );
     }
     throw new Error(`Unsupported binary operation '${operator}'.`);
   }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -3,7 +3,11 @@ import {Color, Interval, Temperament, Val, ValBasis} from '../interval.js';
 import {TimeMonzo} from '../monzo.js';
 import * as sonicWeaveAstParser from './sonic-weave-ast.js';
 import {CSS_COLOR_CONTEXT} from '../css-colors.js';
-import {SonicWeaveValue, SonicWeavePrimitive} from '../stdlib/index.js';
+import {
+  SonicWeaveValue,
+  SonicWeavePrimitive,
+  SonicWeaveFunction,
+} from '../stdlib/index.js';
 import {BUILTIN_CONTEXT} from '../stdlib/builtin/index.js';
 import {PRELUDE_SOURCE, PRELUDE_VOLATILES} from '../stdlib/prelude.js';
 import {RootContext} from '../context.js';
@@ -173,13 +177,17 @@ export function evaluateExpression(
   return subVisitor.visit(finalStatement.expression);
 }
 
-function convert(value: any): SonicWeaveValue {
+function convert(value: unknown): SonicWeaveValue {
   switch (typeof value) {
     case 'string':
     case 'undefined':
-    case 'function':
     case 'boolean':
       return value;
+    case 'function':
+      if ('__doc__' in value && '__node__' in value) {
+        return value as SonicWeaveFunction;
+      }
+      throw new Error('Template functions must conform to SonicWeaveFunction.');
     case 'number':
       if (Number.isInteger(value)) {
         return Interval.fromInteger(value);
@@ -205,10 +213,11 @@ function convert(value: any): SonicWeaveValue {
       } else if (Array.isArray(value)) {
         return value.map(convert) as Interval[];
       } else {
+        const record = value as Record<string, unknown>;
         const result: Record<string, SonicWeavePrimitive> = {};
-        for (const key in value) {
-          if (hasOwn(value, key)) {
-            result[key] = convert(value[key]) as SonicWeavePrimitive;
+        for (const key in record) {
+          if (hasOwn(record, key)) {
+            result[key] = convert(record[key]) as SonicWeavePrimitive;
           }
         }
         return result;
@@ -231,7 +240,7 @@ export function createTag(
   extraBuiltins?: Record<string, SonicWeaveValue>,
   escapeStrings = false,
 ) {
-  function tag(strings: TemplateStringsArray, ...args: any[]) {
+  function tag(strings: TemplateStringsArray, ...args: unknown[]) {
     const fragments = escapeStrings ? strings : strings.raw;
     const visitor = getSourceVisitor(includePrelude, extraBuiltins);
     if (!visitor.rootContext) {
@@ -299,7 +308,7 @@ Object.defineProperty(swr, 'name', {
  */
 export const sw$r = createTag(false) as (
   strings: TemplateStringsArray,
-  ...args: any[]
+  ...args: unknown[]
 ) => Interval[];
 Object.defineProperty(swr, 'name', {
   value: 'sw$r',
@@ -336,7 +345,7 @@ Object.defineProperty(sw, 'name', {
  */
 export const sw$ = createTag(false, true, undefined, true) as (
   strings: TemplateStringsArray,
-  ...args: any[]
+  ...args: unknown[]
 ) => Interval[];
 Object.defineProperty(swr, 'name', {
   value: 'sw$',

--- a/src/parser/statement.ts
+++ b/src/parser/statement.ts
@@ -1285,43 +1285,39 @@ export class StatementVisitor {
   }
 
   protected visitTryStatement(node: TryStatement) {
+    let pendingInterrupt: Interrupt | undefined;
     try {
       const interrupt = this.visit(node.body);
       if (interrupt) {
-        return interrupt;
+        pendingInterrupt = interrupt;
       }
     } catch (e) {
       if (node.handler && node.handler.parameter) {
-        if (e instanceof Error) {
-          // eslint-disable-next-line no-ex-assign
-          e = e.message;
-        }
+        const thrown = e instanceof Error ? e.message : e;
         const handlerVisitor = new StatementVisitor(this);
         handlerVisitor.mutables.delete('$'); // Collapse scope
         handlerVisitor.immutables.set(
           node.handler.parameter.id,
-          e as SonicWeaveValue,
+          thrown as SonicWeaveValue,
         );
         const interrupt = handlerVisitor.visit(node.handler.body);
         if (interrupt) {
-          return interrupt;
+          pendingInterrupt = interrupt;
         }
       } else if (node.handler) {
         const interrupt = this.visit(node.handler.body);
         if (interrupt) {
-          return interrupt;
-        }
-      }
-    } finally {
-      if (node.finalizer) {
-        const interrupt = this.visit(node.finalizer);
-        if (interrupt) {
-          // eslint-disable-next-line no-unsafe-finally
-          return interrupt;
+          pendingInterrupt = interrupt;
         }
       }
     }
-    return undefined;
+    if (node.finalizer) {
+      const interrupt = this.visit(node.finalizer);
+      if (interrupt) {
+        return interrupt;
+      }
+    }
+    return pendingInterrupt;
   }
 
   protected visitIfStatement(node: IfStatement) {
@@ -1350,7 +1346,6 @@ export class StatementVisitor {
       docstring = node.body[0].expression.value;
       node.body.shift();
     }
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const scopeParent = this;
 
     function realization(this: ExpressionVisitor, ...args: SonicWeaveValue[]) {

--- a/src/stdlib/__tests__/runtime.spec.ts
+++ b/src/stdlib/__tests__/runtime.spec.ts
@@ -19,7 +19,7 @@ describe('ternaryBroadcast', () => {
   it('broadcasts three arrays elementwise', () => {
     const context = createContext();
     const result = ternaryBroadcast.call(
-      context as any,
+      context as unknown,
       ['a', 'b'],
       ['x', 'y'],
       ['1', '2'],
@@ -33,7 +33,7 @@ describe('ternaryBroadcast', () => {
   it('broadcasts a scalar pair over an array operand', () => {
     const context = createContext();
     const result = ternaryBroadcast.call(
-      context as any,
+      context as unknown,
       'L',
       'M',
       ['1', '2'],
@@ -49,7 +49,7 @@ describe('ternaryBroadcast', () => {
 
     expect(() =>
       ternaryBroadcast.call(
-        context as any,
+        context as unknown,
         ['a', 'b'],
         ['x'],
         ['1', '2'],

--- a/src/stdlib/builtin/index.ts
+++ b/src/stdlib/builtin/index.ts
@@ -149,7 +149,7 @@ lll.__node__ = builtinNode(lll);
 // == Third-party wrappers ==
 function kCombinations(
   this: ExpressionVisitor,
-  set: any[],
+  set: unknown[],
   k: SonicWeaveValue,
 ) {
   requireParameters({set});
@@ -304,7 +304,7 @@ function simplify(
   if (isArrayOrRecord(interval)) {
     return unaryBroadcast.bind(this)(interval, simplify.bind(this));
   }
-  return pubSimplify(interval as any);
+  return pubSimplify(interval as Interval | boolean);
 }
 simplify.__doc__ =
   'Get rid of interval formatting. Simplifies a ratio to lowest terms.';
@@ -598,10 +598,10 @@ function nedji(
     );
   }
   if (typeof interval === 'string') {
-    let [fraction, equave] = interval.replace('ed', '<').split('<');
-    if (equave.endsWith('>')) {
-      equave = equave.slice(0, -1);
-    }
+    const [fraction, equavePart] = interval.replace('ed', '<').split('<');
+    const equave = equavePart.endsWith('>')
+      ? equavePart.slice(0, -1)
+      : equavePart;
     const monzo = TimeMonzo.fromEqualTemperament(
       fraction.replace('\\', '/'),
       equave,
@@ -1642,12 +1642,12 @@ slice.__doc__ =
   'Obtain a slice of a string or scale between the given indices.';
 slice.__node__ = builtinNode(slice);
 
-function zip(...args: any[][]) {
+function zip(...args: unknown[][]) {
   if (!args.length) {
     return [];
   }
   const minLength = Math.min(...args.map(a => a.length));
-  const result: any[][] = [];
+  const result: unknown[][] = [];
   for (let i = 0; i < minLength; ++i) {
     result.push(args.map(a => a[i]));
   }
@@ -1657,12 +1657,12 @@ zip.__doc__ =
   'Combine elements of each array into tuples until one of them is exhausted.';
 zip.__node__ = builtinNode(zip);
 
-function zipLongest(...args: any[][]) {
+function zipLongest(...args: unknown[][]) {
   if (!args.length) {
     return [];
   }
   const maxLength = Math.max(...args.map(a => a.length));
-  const result: any[][] = [];
+  const result: unknown[][] = [];
   for (let i = 0; i < maxLength; ++i) {
     result.push(args.map(a => a[i]));
   }
@@ -2153,8 +2153,8 @@ length.__node__ = builtinNode(length, PARENT_SCALE);
 
 function map(
   this: ExpressionVisitor,
-  mapper: (value: any, index: Interval, array: any[]) => unknown,
-  scale?: any[],
+  mapper: (value: unknown, index: Interval, array: unknown[]) => unknown,
+  scale?: unknown[],
 ) {
   requireParameters({mapper});
   mapper = mapper.bind(this);
@@ -2168,8 +2168,8 @@ map.__node__ = builtinNode(map, PARENT_SCALE);
 
 function remap(
   this: ExpressionVisitor,
-  mapper: (value: any, index: Interval, array: any[]) => unknown,
-  scale?: any[],
+  mapper: (value: unknown, index: Interval, array: unknown[]) => unknown,
+  scale?: unknown[],
 ) {
   requireParameters({mapper});
   scale ??= this.currentScale;
@@ -2183,8 +2183,12 @@ remap.__node__ = builtinNode(remap, PARENT_SCALE);
 
 function filter(
   this: ExpressionVisitor,
-  tester: (value: any, index: Interval, array: any[]) => SonicWeaveValue,
-  scale?: any[],
+  tester: (
+    value: unknown,
+    index: Interval,
+    array: unknown[],
+  ) => SonicWeaveValue,
+  scale?: unknown[],
 ) {
   requireParameters({tester});
   tester = tester.bind(this);
@@ -2199,8 +2203,12 @@ filter.__node__ = builtinNode(filter, PARENT_SCALE);
 
 function distill(
   this: ExpressionVisitor,
-  tester: (value: any, index: Interval, array: any[]) => SonicWeaveValue,
-  scale?: any[],
+  tester: (
+    value: unknown,
+    index: Interval,
+    array: unknown[],
+  ) => SonicWeaveValue,
+  scale?: unknown[],
 ) {
   requireParameters({tester});
   scale ??= this.currentScale;
@@ -2215,13 +2223,13 @@ distill.__node__ = builtinNode(distill, PARENT_SCALE);
 function arrayReduce(
   this: ExpressionVisitor,
   reducer: (
-    previousValue: any,
-    currentValue: any,
+    previousValue: unknown,
+    currentValue: unknown,
     currentIndex: Interval,
-    array: any[],
-  ) => any,
-  scale?: any[],
-  initialValue?: any,
+    array: unknown[],
+  ) => unknown,
+  scale?: unknown[],
+  initialValue?: unknown,
 ) {
   requireParameters({reducer});
   if (!(typeof reducer === 'function')) {
@@ -2248,7 +2256,7 @@ arrayReduce.__node__ = builtinNode(arrayReduce, PARENT_SCALE);
 function arrayRepeat(
   this: ExpressionVisitor,
   count: Interval,
-  scale?: any[] | string,
+  scale?: unknown[] | string,
 ) {
   requireParameters({count});
   const c = count.toInteger();
@@ -2268,15 +2276,15 @@ arrayRepeat.__node__ = builtinNode(arrayRepeat, PARENT_SCALE);
 
 function some(
   this: ExpressionVisitor,
-  array?: any[],
-  test?: (value: any, index: Interval, array: any[]) => unknown,
+  array?: unknown[],
+  test?: (value: unknown, index: Interval, array: unknown[]) => unknown,
 ) {
   if (!array) {
     array = this.currentScale;
   }
   this.spendGas(array.length);
   if (!test) {
-    return array.some(sonicTruth);
+    return array.some(v => sonicTruth(v as SonicWeaveValue));
   }
   return array.some((v, i, arr) => test(v, fromInteger(i), arr));
 }
@@ -2286,15 +2294,15 @@ some.__node__ = builtinNode(some, PARENT_SCALE);
 
 function every(
   this: ExpressionVisitor,
-  array?: any[],
-  test?: (value: any, index: Interval, array: any[]) => unknown,
+  array?: unknown[],
+  test?: (value: unknown, index: Interval, array: unknown[]) => unknown,
 ) {
   if (!array) {
     array = this.currentScale;
   }
   this.spendGas(array.length);
   if (!test) {
-    return array.every(sonicTruth);
+    return array.every(v => sonicTruth(v as SonicWeaveValue));
   }
   return array.every((v, i, arr) => test(v, fromInteger(i), arr));
 }
@@ -2377,21 +2385,25 @@ lstr.__doc__ =
   'Obtain a "best effort" short string representing a primitive value. Vectorizes over arrays.';
 lstr.__node__ = builtinNode(lstr);
 
-function print(this: ExpressionVisitor, ...args: any[]) {
+function print(this: ExpressionVisitor, ...args: unknown[]) {
   const s = repr.bind(this);
-  console.log(...args.map(a => (typeof a === 'string' ? a : s(a))));
+  console.log(
+    ...args.map(a => (typeof a === 'string' ? a : s(a as SonicWeaveValue))),
+  );
 }
 print.__doc__ = 'Print the arguments to the console.';
 print.__node__ = builtinNode(print);
 
-function warn(this: ExpressionVisitor, ...args: any[]) {
+function warn(this: ExpressionVisitor, ...args: unknown[]) {
   const s = repr.bind(this);
-  console.log(...args.map(a => (typeof a === 'string' ? a : s(a))));
+  console.log(
+    ...args.map(a => (typeof a === 'string' ? a : s(a as SonicWeaveValue))),
+  );
 }
 warn.__doc__ = 'Print the arguments to the console with "warning" emphasis.';
 warn.__node__ = builtinNode(warn);
 
-function dir(arg: any) {
+function dir(arg: unknown) {
   console.dir(arg, {depth: null});
 }
 dir.__doc__ = 'Obtain the javascript representation of the value.';
@@ -2480,7 +2492,13 @@ function centsColor(
 ): Color | Color[] {
   if (Array.isArray(interval)) {
     this.spendGas(interval.length);
-    return interval.map(centsColor as any);
+    return interval.map(
+      centsColor as (
+        value: SonicWeavePrimitive,
+        index: number,
+        array: SonicWeavePrimitive[],
+      ) => Color,
+    );
   }
   return pubCentsColor.bind(this.rootContext)(upcastBool(interval));
 }
@@ -2494,7 +2512,13 @@ export function factorColor(
 ): Color | Color[] {
   if (Array.isArray(interval)) {
     this.spendGas(interval.length);
-    return interval.map(factorColor as any);
+    return interval.map(
+      factorColor as (
+        value: SonicWeavePrimitive,
+        index: number,
+        array: SonicWeavePrimitive[],
+      ) => Color,
+    );
   }
   return pubFactorColor.bind(this.rootContext)(upcastBool(interval));
 }

--- a/src/stdlib/public.ts
+++ b/src/stdlib/public.ts
@@ -124,7 +124,10 @@ export function linear(interval: Interval | boolean): Interval {
  * @param interval Interval to convert.
  * @returns The interval in the logarithmic domain with the underlying value unmodified.
  */
-export function logarithmic(this: any, interval: Interval | boolean): Interval {
+export function logarithmic(
+  this: unknown,
+  interval: Interval | boolean,
+): Interval {
   interval = upcastBool(interval);
   if (interval.domain === 'logarithmic') {
     return interval.shallowClone();

--- a/src/stdlib/runtime.ts
+++ b/src/stdlib/runtime.ts
@@ -6,9 +6,8 @@ import {
   Expression,
 } from '../ast.js';
 import {Color, Interval, Temperament, Val, ValBasis} from '../interval.js';
-import {TimeMonzo, TimeReal} from '../monzo.js';
+import {TimeReal} from '../monzo.js';
 import {type ExpressionVisitor} from '../parser/expression.js';
-import {ZERO} from '../utils.js';
 
 /**
  * Function that can be called inside the SonicWeave runtime.
@@ -47,9 +46,6 @@ export type SonicWeaveValue =
   | SonicWeavePrimitive
   | SonicWeavePrimitive[]
   | Record<string, SonicWeavePrimitive>;
-
-const ZERO_MONZO = new TimeMonzo(ZERO, [], ZERO);
-const ONE_MONZO = new TimeMonzo(ZERO, []);
 
 const INT_CACHE = [...Array(100).keys()].map(i => Interval.fromInteger(i));
 
@@ -141,9 +137,9 @@ export function builtinNode(
     .map(p => ({type: 'Parameter', id: p, defaultValue: null}));
   for (const parameter of parameters) {
     if (parameter.id.includes('=')) {
-      let [id, defaultValue] = parameter.id.split('=');
-      parameter.id = id.trim();
-      defaultValue = defaultValue.trim().replace(/'/g, '"');
+      const [idPart, defaultValuePart] = parameter.id.split('=');
+      parameter.id = idPart.trim();
+      const defaultValue = defaultValuePart.trim().replace(/'/g, '"');
       if (defaultValue.includes('"')) {
         parameter.defaultValue = {
           type: 'StringLiteral',
@@ -183,7 +179,7 @@ export function builtinNode(
  * @returns Nothing.
  * @throws An error naming the first missing parameter.
  */
-export function requireParameters(parameters: Record<string, any>) {
+export function requireParameters(parameters: Record<string, unknown>) {
   for (const name of Object.keys(parameters)) {
     if (parameters[name] === undefined) {
       throw new Error(`Parameter '${name}' is required.`);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -167,7 +167,8 @@ function setUnionPolyfill<T>(a: Set<T>, b: Set<T>) {
  * @returns New set that contains elements of both sets (without duplicates).
  */
 function setUnionNative<T>(a: Set<T>, b: Set<T>): Set<T> {
-  return (a as any).union(b);
+  const setWithUnion = a as Set<T> & {union(other: Set<T>): Set<T>};
+  return setWithUnion.union(b);
 }
 
 export const setUnion =
@@ -181,7 +182,10 @@ export const setUnion =
  */
 export function hasOwn(object: object, property: PropertyKey) {
   if ('hasOwn' in Object) {
-    return (Object as any).hasOwn(object, property);
+    const objectWithHasOwn = Object as typeof Object & {
+      hasOwn(obj: object, prop: PropertyKey): boolean;
+    };
+    return objectWithHasOwn.hasOwn(object, property);
   }
   return Object.prototype.hasOwnProperty.call(object, property);
 }


### PR DESCRIPTION
Fix lint fallout.
Fix minor bugs and oversights revealed by the new linting rules.